### PR TITLE
소셜 로그인 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.apache.commons:commons-lang3:3.14.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/whatpl/account/Account.java
+++ b/src/main/java/com/whatpl/account/Account.java
@@ -1,0 +1,42 @@
+package com.whatpl.account;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "account",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_account_registration_provider",
+                        columnNames = {"registration_id", "provider_id"})})
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_id")
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    @Column(length = 50)
+    private String email;
+
+    @Column(name = "registration_id", length = 30)
+    private String registrationId;
+
+    @Column(name = "provider_id", length = 100)
+    private String providerId;
+
+    @Builder
+    public Account(String name, String email, String registrationId, String providerId) {
+        this.name = name;
+        this.email = email;
+        this.registrationId = registrationId;
+        this.providerId = providerId;
+    }
+}

--- a/src/main/java/com/whatpl/account/AccountRepository.java
+++ b/src/main/java/com/whatpl/account/AccountRepository.java
@@ -1,0 +1,10 @@
+package com.whatpl.account;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Optional<Account> findByRegistrationIdAndProviderId(String registrationId, String providerId);
+}

--- a/src/main/java/com/whatpl/account/AccountService.java
+++ b/src/main/java/com/whatpl/account/AccountService.java
@@ -1,0 +1,36 @@
+package com.whatpl.account;
+
+import com.whatpl.security.domain.AccountPrincipal;
+import com.whatpl.security.domain.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+
+    private Account createAccount(OAuth2UserInfo oAuth2UserInfo) {
+        Account account = Account.builder()
+                .name(oAuth2UserInfo.getName())
+                .email(oAuth2UserInfo.getEmail())
+                .registrationId(oAuth2UserInfo.getRegistrationId())
+                .providerId(oAuth2UserInfo.getProviderId())
+                .build();
+        return accountRepository.save(account);
+    }
+
+    @Transactional
+    public AccountPrincipal getOrCreateAccount(OAuth2UserInfo oAuth2UserInfo) {
+        Account account = accountRepository.findByRegistrationIdAndProviderId(
+                        oAuth2UserInfo.getRegistrationId(),
+                        oAuth2UserInfo.getProviderId())
+                .orElseGet(() -> createAccount(oAuth2UserInfo));
+
+        return new AccountPrincipal(account.getName(), "", Collections.emptySet(), oAuth2UserInfo);
+    }
+}

--- a/src/main/java/com/whatpl/security/config/SecurityConfig.java
+++ b/src/main/java/com/whatpl/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.whatpl.security.config;
 
 import com.whatpl.account.AccountService;
+import com.whatpl.security.repository.CookieOAuth2AuthorizationRequestRepository;
 import com.whatpl.security.service.AccountOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -36,7 +37,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
-                                .userService(new AccountOAuth2UserService(accountService))))
+                                .userService(new AccountOAuth2UserService(accountService)))
+                        .authorizationEndpoint(auth -> auth
+                                .authorizationRequestRepository(new CookieOAuth2AuthorizationRequestRepository())))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable);

--- a/src/main/java/com/whatpl/security/config/SecurityConfig.java
+++ b/src/main/java/com/whatpl/security/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.whatpl.security.config;
 
+import com.whatpl.account.AccountService;
+import com.whatpl.security.service.AccountOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -9,8 +11,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -21,11 +21,6 @@ public class SecurityConfig {
 
     private static final String[] WEB_SECURITY_WHITE_LIST = {"/", "/login*", "oauth2*", "/error*"};
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
     /*
      * 일반적인 정적자원들의 보안설정 해제
      */
@@ -35,10 +30,13 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, AccountService accountService) throws Exception {
         http.authorizeHttpRequests(auth -> auth
                         .requestMatchers(WEB_SECURITY_WHITE_LIST).permitAll()
                         .anyRequest().authenticated())
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(new AccountOAuth2UserService(accountService))))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable);

--- a/src/main/java/com/whatpl/security/domain/AccountPrincipal.java
+++ b/src/main/java/com/whatpl/security/domain/AccountPrincipal.java
@@ -1,0 +1,30 @@
+package com.whatpl.security.domain;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class AccountPrincipal extends User implements OAuth2User {
+
+    private final OAuth2UserInfo oAuth2UserInfo;
+
+    public AccountPrincipal(String username, String password, Collection<? extends GrantedAuthority> authorities, OAuth2UserInfo oAuth2UserInfo) {
+        super(username, password, authorities);
+        this.oAuth2UserInfo = oAuth2UserInfo;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2UserInfo.getAttributes();
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2UserInfo.getName();
+    }
+}

--- a/src/main/java/com/whatpl/security/domain/OAuth2UserAttributes.java
+++ b/src/main/java/com/whatpl/security/domain/OAuth2UserAttributes.java
@@ -1,0 +1,57 @@
+package com.whatpl.security.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2UserAttributes {
+
+    GOOGLE(attributes -> new OAuth2UserInfo(
+            attributes,
+            "google",
+            attributes.get("sub").toString(),
+            attributes.get("email").toString(),
+            attributes.get("name").toString()
+    )),
+
+    NAVER(attributes -> {
+        @SuppressWarnings("unchecked") // 네이버에서 보내온 api가 변경되지 않으면 타입캐스팅 안전
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return new OAuth2UserInfo(
+                response,
+                "naver",
+                response.get("id").toString(),
+                response.get("email").toString(),
+                response.get("name").toString()
+        );
+    }),
+
+    KAKAO(attributes -> {
+        @SuppressWarnings("unchecked") // 카카오에서 보내온 api가 변경되지 않으면 타입캐스팅 안전
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        @SuppressWarnings("unchecked") // 카카오에서 보내온 api가 변경되지 않으면 타입캐스팅 안전
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return new OAuth2UserInfo(
+                profile,
+                "kakao",
+                attributes.get("id").toString(),
+                null,
+                profile.get("nickname").toString()
+        );
+    });
+
+    private final Function<Map<String, Object>, OAuth2UserInfo> getOAuth2UserInfo;
+
+    public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+        return Arrays.stream(values())
+                .filter(provider -> provider.name().toLowerCase().equals(registrationId))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new)
+                .getOAuth2UserInfo.apply(attributes);
+    }
+}

--- a/src/main/java/com/whatpl/security/domain/OAuth2UserInfo.java
+++ b/src/main/java/com/whatpl/security/domain/OAuth2UserInfo.java
@@ -1,0 +1,22 @@
+package com.whatpl.security.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class OAuth2UserInfo {
+
+    /** AuthorizationServer 에서 제공받은 정보 */
+    private final Map<String, Object> attributes;
+    /** AuthorizationServer id */
+    private final String registrationId;
+    /** AuthorizationServer 에서 관리중인 사용자 고유값 */
+    private final String providerId;
+    /** 사용자 이메일 */
+    private final String email;
+    /** 사용자 이름 */
+    private final String name;
+}

--- a/src/main/java/com/whatpl/security/repository/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/whatpl/security/repository/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,64 @@
+package com.whatpl.security.repository;
+
+import com.whatpl.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.Assert;
+
+public class CookieOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "OAUTH2_AUTH_REQUEST";
+    private static final int OAUTH2_COOKIE_EXPIRATION_SECONDS = 30 * 60;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Assert.notNull(request, "request cannot be null");
+        String stateParameter = getStateParameter(request);
+        if (stateParameter == null) {
+            return null;
+        }
+        OAuth2AuthorizationRequest authorizationRequest = getAuthorizationRequest(request);
+        return (authorizationRequest != null && stateParameter.equals(authorizationRequest.getState()))
+                ? authorizationRequest : null;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        Assert.notNull(request, "request cannot be null");
+        Assert.notNull(response, "response cannot be null");
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+        String state = authorizationRequest.getState();
+        Assert.hasText(state, "authorizationRequest.state cannot be empty");
+        CookieUtils.addCookie(response,
+                OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                CookieUtils.serialize(authorizationRequest),
+                OAUTH2_COOKIE_EXPIRATION_SECONDS);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        Assert.notNull(response, "response cannot be null");
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+        if (authorizationRequest != null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        }
+        return authorizationRequest;
+    }
+
+    private String getStateParameter(HttpServletRequest request) {
+        return request.getParameter(OAuth2ParameterNames.STATE);
+    }
+
+    private OAuth2AuthorizationRequest getAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/whatpl/security/service/AccountOAuth2UserService.java
+++ b/src/main/java/com/whatpl/security/service/AccountOAuth2UserService.java
@@ -1,0 +1,26 @@
+package com.whatpl.security.service;
+
+import com.whatpl.account.AccountService;
+import com.whatpl.security.domain.OAuth2UserAttributes;
+import com.whatpl.security.domain.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class AccountOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final AccountService accountService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserAttributes.of(registrationId, oAuth2User.getAttributes());
+
+        return accountService.getOrCreateAccount(oAuth2UserInfo);
+    }
+}

--- a/src/main/java/com/whatpl/util/CookieUtils.java
+++ b/src/main/java/com/whatpl/util/CookieUtils.java
@@ -1,0 +1,65 @@
+package com.whatpl.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.SerializationUtils;
+import org.springframework.http.ResponseCookie;
+import org.springframework.util.StringUtils;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+public final class CookieUtils {
+
+    private CookieUtils() {
+        throw new IllegalStateException("This is Utility class!");
+    }
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        if (!StringUtils.hasText(name) || request.getCookies() == null) return Optional.empty();
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .sameSite("none")
+                .path("/")
+                .maxAge(maxAge)
+                .secure(true)
+                .httpOnly(true)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        if (request.getCookies() == null) return;
+
+        Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .forEach(cookie -> {
+                    ResponseCookie responseCookie = ResponseCookie.from(name, "")
+                            .sameSite("none")
+                            .path("/")
+                            .maxAge(0)
+                            .secure(true)
+                            .httpOnly(true)
+                            .build();
+                    response.addHeader("Set-Cookie", responseCookie.toString());
+                });
+    }
+
+    public static String serialize(Serializable object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T extends Serializable> T deserialize(Cookie cookie, Class<T> clazz) {
+        return clazz.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,43 @@ spring:
       ddl-auto: create
     database: mysql
 
+  # 아래 정보는 ClientRegistration 에 저장됨
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${OAUTH2_CLIENT_ID_GOOGLE}
+            client-secret: ${OAUTH2_CLIENT_SECRET_GOOGLE}
+            scope:
+              - profile
+              - email
+          naver:
+            client-id: ${OAUTH2_CLIENT_ID_NAVER}
+            client-secret: ${OAUTH2_CLIENT_SECRET_NAVER}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+          kakao:
+            client-id: ${OAUTH2_CLIENT_ID_KAKAO}
+            client-secret: ${OAUTH2_CLIENT_SECRET_KAKAO}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname # 카카오는 비즈앱 아니면 닉네임, 프로필만 가능..
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 decorator:
   datasource:
     p6spy:

--- a/src/test/java/com/whatpl/oauth2/OAuth2ApiTest.java
+++ b/src/test/java/com/whatpl/oauth2/OAuth2ApiTest.java
@@ -1,0 +1,58 @@
+package com.whatpl.oauth2;
+
+import com.whatpl.account.AccountService;
+import com.whatpl.security.config.SecurityConfig;
+import com.whatpl.util.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@WebMvcTest
+@Import(SecurityConfig.class)
+public class OAuth2ApiTest {
+
+    private static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "OAUTH2_AUTH_REQUEST";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    AccountService accountService;
+
+    @Test
+    @DisplayName("인가코드 요청 API 호출시 리다이렉트 되고, AuthorizationRequest 검증용 Cookie 가 발급된다.")
+    void codeTest() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/oauth2/authorization/naver"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(cookie().exists(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME))
+                .andExpect(cookie().httpOnly(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, true))
+                .andExpect(cookie().secure(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, true))
+                .andExpect(cookie().sameSite(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "none"))
+                .andDo(print())
+                .andReturn();
+
+        Cookie cookie = mvcResult.getResponse().getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        assertNotNull(cookie);
+        assertNotNull(cookie.getValue());
+        assertNotEquals(0, cookie.getValue().length());
+
+        OAuth2AuthorizationRequest authorizationRequest = CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+        assertNotNull(authorizationRequest);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #5 

## 📝작업 내용

- 구글, 네이버, 카카오 OAuth2.0 기반 소셜 로그인 구현
- Account(사용자 계정) 엔티티 생성
- 소셜 로그인 이후 존재하는 계정이면 로그인 / 존재하지 않는 계정이면 회원가입 하도록 로직 구성
- 존재하는 사용자 여부는 Account엔티티의 registrationId, providerId로 구분합니다. ( Unique Key 로 설정했습니다. )
- 소셜 로그인 시 스프링 시큐리티는 AuthorizationRequest 저장소로 HttpSessionOAuth2AuthorizationRequestRepository 를 기본으로 제공합니다.
  - 세션을 저장소로 사용할 경우 여러 문제가 있을 수 있습니다. (ex. load balancing 된 아키텍처)
  - 저희 서비스도 nginx 를 이용해 httpRequest 를 load balancing 할 예정이기 때문에 세션을 저장소로 이용할 경우 문제 발생 소지가 있습니다.
  - 이런 이유로 쿠키를 이용해 AuthorizationRequest 를 검증하도록 했습니다. (CookieOAuth2AuthorizationRequestRepository 를 참고하세요.)
  - 저희 프론트엔드 - 백엔드 구조가 cross-origin 이기 때문에 쿠키에 아무런 설정도 하지 않으면 프론트엔드에서 쿠키가 저장되지도 않고, 백엔드로 쿠키를 보내지도 못합니다.
  - 따라서, 백엔드에서 쿠키를 발급할 때 **httpOnly=true, secure=true, sameSite=none** 으로 설정했습니다.
  - 그리고, cross-orign 환경에서 Credentials (인증서 - 쿠키, 인증헤더 등등..) 를 공유하기 위해 응답 헤더에 Access-Control-Allow-Credentials=true 를 설정했습니다. (응답 헤더 설정은 nginx 에 설정했습니다.)

## 💬리뷰 요구사항(선택)
