### PR TITLE
프로필 필수 정보 입력

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,10 @@ dependencies {
 	implementation 'org.apache.commons:commons-lang3:3.14.0'
 
 	compileOnly 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,10 @@ dependencies {
 	implementation 'org.apache.commons:commons-lang3:3.14.0'
 
 	compileOnly 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 
@@ -123,4 +123,8 @@ bootJar {
     from("${generateSwaggerUISample.outputDir}") {
         into 'static/docs'
     }
+}
+
+jar {
+	enabled = false
 }

--- a/src/main/java/com/whatpl/attachment/service/AttachmentService.java
+++ b/src/main/java/com/whatpl/attachment/service/AttachmentService.java
@@ -6,6 +6,7 @@ import com.whatpl.attachment.repository.AttachmentRepository;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.upload.S3Uploader;
+import com.whatpl.global.util.FileUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -22,10 +23,11 @@ public class AttachmentService {
     @Transactional
     public Long upload(MultipartFile multipartFile) {
         String storedName = s3Uploader.upload(multipartFile);
+        String mimeType = FileUtils.extractMimeType(multipartFile);
         Attachment attachment = Attachment.builder()
                 .fileName(multipartFile.getOriginalFilename())
                 .storedName(storedName)
-                .mimeType(multipartFile.getContentType())
+                .mimeType(mimeType)
                 .build();
         Attachment savedAttachment = attachmentRepository.save(attachment);
         return savedAttachment.getId();
@@ -40,5 +42,10 @@ public class AttachmentService {
                 .resource(resource)
                 .mimeType(attachment.getMimeType())
                 .build();
+    }
+
+    public Attachment findById(long id) {
+        return attachmentRepository.findById(id)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_FILE));
     }
 }

--- a/src/main/java/com/whatpl/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/whatpl/global/config/JpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package com.whatpl.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaAuditingConfig {
-}

--- a/src/main/java/com/whatpl/global/config/JpaConfig.java
+++ b/src/main/java/com/whatpl/global/config/JpaConfig.java
@@ -1,0 +1,21 @@
+package com.whatpl.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/whatpl/global/exception/DetailErrorResponse.java
+++ b/src/main/java/com/whatpl/global/exception/DetailErrorResponse.java
@@ -1,0 +1,33 @@
+package com.whatpl.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DetailErrorResponse extends ErrorResponse {
+
+    private final List<DetailError> detailErrors;
+
+    public DetailErrorResponse(ErrorResponse errorResponse, List<DetailError> detailErrors) {
+        super(errorResponse.getMessage(), errorResponse.getCode(), errorResponse.getStatus().value());
+        this.detailErrors = detailErrors;
+    }
+
+    @Getter
+    public static class DetailError {
+
+        private final String field;
+        private final Object value;
+        private final String reason;
+
+        @Builder
+        public DetailError(String field, Object value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+    }
+
+}

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
     MISSING_PARAMETER("CMM3", 400, "필수 파라미터가 존재하지 않습니다."),
     NOT_FOUND_API("CMM4", 404, "요청하신 API를 찾을 수 없습니다."),
     REQUEST_VALUE_INVALID("CMM5", 400, "입력값이 올바르지 않습니다."),
-    SKILL_NOT_VALID("CMM6", 400, "기술스택에 유효하지 않은 값이 존재합니다.");
+    SKILL_NOT_VALID("CMM6", 400, "기술스택에 유효하지 않은 값이 존재합니다."),
+    JOB_NOT_VALID("CMM7", 400, "직무에 유효하지 않은 값이 존재합니다."),
+    CAREER_NOT_VALID("CMM7", 400, "경력에 유효하지 않은 값이 존재합니다.");
 
     private final String code;
     private final int status;

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
     GLOBAL_EXCEPTION("CMM1", 500, "서버에서 에러가 발생하였습니다."),
     NOT_FOUND_DATA("CMM2", 404, "데이터가 존재하지 않습니다."),
     MISSING_PARAMETER("CMM3", 400, "필수 파라미터가 존재하지 않습니다."),
-    NOT_FOUND_API("CMM4", 404, "요청하신 API를 찾을 수 없습니다.");
+    NOT_FOUND_API("CMM4", 404, "요청하신 API를 찾을 수 없습니다."),
+    REQUEST_VALUE_INVALID("CMM5", 400, "입력값이 올바르지 않습니다."),
+    SKILL_NOT_VALID("CMM6", 400, "기술스택에 유효하지 않은 값이 존재합니다.");
 
     private final String code;
     private final int status;

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -10,12 +10,15 @@ public enum ErrorCode {
     // TOKEN
     INVALID_TOKEN("TKN1", 401, "토큰정보가 유효하지 않습니다."),
     EXPIRED_TOKEN("TKN2", 401, "만료된 토큰입니다."),
+    MALFORMED_TOKEN("TKN3", 401, "잘못된 형식의 토큰입니다."),
+    INVALID_SIGNATURE("TKN4", 401, "변조된 토큰입니다."),
 
     // MEMBER
     NOT_FOUND_MEMBER("MBR1", 404, "사용자를 찾을 수 없습니다."),
     LOGIN_FAILED("MBR2", 401, "로그인에 실패했습니다."),
     NO_AUTHENTICATION("MBR3", 401, "인증되지 않은 사용자입니다."),
     NO_AUTHORIZATION("MBR4", 403, "접근권한이 없습니다."),
+    HAS_NO_PROFILE("MBR5", 401, "프로필이 작성되지 않은 사용자입니다."),
 
     // FILE
     NOT_FOUND_FILE("FILE1", 404, "파일을 찾을 수 없습니다."),
@@ -30,7 +33,7 @@ public enum ErrorCode {
     REQUEST_VALUE_INVALID("CMM5", 400, "입력값이 올바르지 않습니다."),
     SKILL_NOT_VALID("CMM6", 400, "기술스택에 유효하지 않은 값이 존재합니다."),
     JOB_NOT_VALID("CMM7", 400, "직무에 유효하지 않은 값이 존재합니다."),
-    CAREER_NOT_VALID("CMM7", 400, "경력에 유효하지 않은 값이 존재합니다.");
+    CAREER_NOT_VALID("CMM8", 400, "경력에 유효하지 않은 값이 존재합니다.");
 
     private final String code;
     private final int status;

--- a/src/main/java/com/whatpl/global/jwt/JwtService.java
+++ b/src/main/java/com/whatpl/global/jwt/JwtService.java
@@ -46,6 +46,7 @@ public class JwtService {
                 .and()
                 .subject(String.valueOf(principal.getId()))
                 .claim(WhatplClaim.NICKNAME.getKey(), principal.getUsername())
+                .claim(WhatplClaim.HAS_PROFILE.getKey(), principal.getHasProfile())
                 .issuer("jewoos.site")
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.getAccessExpirationTime()))
                 .signWith(jwtProperties.getSecretKey())
@@ -90,7 +91,7 @@ public class JwtService {
     }
 
     private UsernamePasswordAuthenticationToken createAuthenticationToken(Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findMemberWithAllById(memberId)
                         .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
         MemberPrincipal principal = MemberPrincipal.from(member);
         return new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), Collections.emptySet());
@@ -110,8 +111,9 @@ public class JwtService {
 
     private MemberPrincipal getMemberPrincipal(Jws<Claims> claims) {
         long id = Long.parseLong(claims.getPayload().getSubject());
-        String name = claims.getPayload().get(WhatplClaim.NICKNAME.getKey()).toString();
-        return new MemberPrincipal(id, name, "", Collections.emptySet());
+        String nickname = claims.getPayload().get(WhatplClaim.NICKNAME.getKey()).toString();
+        boolean hasProfile = Boolean.getBoolean(claims.getPayload().get(WhatplClaim.HAS_PROFILE.getKey()).toString());
+        return new MemberPrincipal(id, hasProfile, nickname, "", Collections.emptySet());
     }
 
     private Jws<Claims> parseJwt(String jwt) {

--- a/src/main/java/com/whatpl/global/jwt/JwtService.java
+++ b/src/main/java/com/whatpl/global/jwt/JwtService.java
@@ -92,7 +92,7 @@ public class JwtService {
     private UsernamePasswordAuthenticationToken createAuthenticationToken(Long memberId) {
         Member member = memberRepository.findById(memberId)
                         .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
-        MemberPrincipal principal = MemberPrincipal.of(member);
+        MemberPrincipal principal = MemberPrincipal.from(member);
         return new UsernamePasswordAuthenticationToken(principal, "", Collections.emptySet());
     }
 
@@ -111,7 +111,7 @@ public class JwtService {
     private MemberPrincipal getMemberPrincipal(Jws<Claims> claims) {
         long id = Long.parseLong(claims.getPayload().getSubject());
         String name = claims.getPayload().get("name").toString();
-        return new MemberPrincipal(id, name, "", Collections.emptySet(), null);
+        return new MemberPrincipal(id, name, "", Collections.emptySet());
     }
 
     private Jws<Claims> parseJwt(String jwt) {

--- a/src/main/java/com/whatpl/global/jwt/JwtService.java
+++ b/src/main/java/com/whatpl/global/jwt/JwtService.java
@@ -29,7 +29,7 @@ public class JwtService {
     private final JwtProperties jwtProperties;
     private final RedisService redisService;
     private final MemberRepository memberRepository;
-    private final static String PREFIX_REFRESH_TOKEN = "refreshToken::";
+    private static final String PREFIX_REFRESH_TOKEN = "refreshToken:";
 
     /**
      * accessToken 을 발급한다.
@@ -45,7 +45,7 @@ public class JwtService {
                 .type("JWT")
                 .and()
                 .subject(String.valueOf(principal.getId()))
-                .claim("name", principal.getUsername())
+                .claim(WhatplClaim.NICKNAME.getKey(), principal.getUsername())
                 .issuer("jewoos.site")
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.getAccessExpirationTime()))
                 .signWith(jwtProperties.getSecretKey())
@@ -93,7 +93,7 @@ public class JwtService {
         Member member = memberRepository.findById(memberId)
                         .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
         MemberPrincipal principal = MemberPrincipal.from(member);
-        return new UsernamePasswordAuthenticationToken(principal, "", Collections.emptySet());
+        return new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), Collections.emptySet());
     }
 
     /**
@@ -110,7 +110,7 @@ public class JwtService {
 
     private MemberPrincipal getMemberPrincipal(Jws<Claims> claims) {
         long id = Long.parseLong(claims.getPayload().getSubject());
-        String name = claims.getPayload().get("name").toString();
+        String name = claims.getPayload().get(WhatplClaim.NICKNAME.getKey()).toString();
         return new MemberPrincipal(id, name, "", Collections.emptySet());
     }
 

--- a/src/main/java/com/whatpl/global/jwt/WhatplClaim.java
+++ b/src/main/java/com/whatpl/global/jwt/WhatplClaim.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum WhatplClaim {
 
-    NICKNAME("nick");
+    NICKNAME("nick"),
+    HAS_PROFILE("hpf");
 
     private final String key;
 }

--- a/src/main/java/com/whatpl/global/jwt/WhatplClaim.java
+++ b/src/main/java/com/whatpl/global/jwt/WhatplClaim.java
@@ -1,0 +1,13 @@
+package com.whatpl.global.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WhatplClaim {
+
+    NICKNAME("nick");
+
+    private final String key;
+}

--- a/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
+++ b/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
@@ -31,7 +31,6 @@ public class MemberPrincipal extends User implements OAuth2User {
     }
 
     public static MemberPrincipal from(Member member) {
-        return new MemberPrincipal(member.getId(), member.getNickname(), "",
-                Collections.emptyList());
+        return new MemberPrincipal(member.getId(), member.getNickname(), "", Collections.emptySet());
     }
 }

--- a/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
+++ b/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
@@ -15,7 +15,7 @@ public class MemberPrincipal extends User implements OAuth2User {
 
     private final long id;
 
-    public MemberPrincipal(long id, String username, String password, Collection<? extends GrantedAuthority> authorities, OAuth2UserInfo oAuth2UserInfo) {
+    public MemberPrincipal(long id, String username, String password, Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
         this.id = id;
     }
@@ -30,14 +30,8 @@ public class MemberPrincipal extends User implements OAuth2User {
         return super.getUsername();
     }
 
-    public static MemberPrincipal of(Member member) {
-        OAuth2UserInfo userInfo = OAuth2UserInfo.builder()
-                .attributes(Collections.emptyMap())
-                .name(member.getNickname())
-                .registrationId(member.getSocialType().name())
-                .providerId(member.getSocialId())
-                .build();
+    public static MemberPrincipal from(Member member) {
         return new MemberPrincipal(member.getId(), member.getNickname(), "",
-                Collections.emptySet(), userInfo);
+                Collections.emptyList());
     }
 }

--- a/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
+++ b/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
@@ -10,14 +10,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-@Getter
 public class MemberPrincipal extends User implements OAuth2User {
 
+    @Getter
     private final long id;
+    private final boolean hasProfile;
 
-    public MemberPrincipal(long id, String username, String password, Collection<? extends GrantedAuthority> authorities) {
+    public MemberPrincipal(long id, boolean hasProfile, String username, String password, Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
         this.id = id;
+        this.hasProfile = hasProfile;
     }
 
     @Override
@@ -30,7 +32,11 @@ public class MemberPrincipal extends User implements OAuth2User {
         return super.getUsername();
     }
 
+    public boolean getHasProfile() {
+        return hasProfile;
+    }
+
     public static MemberPrincipal from(Member member) {
-        return new MemberPrincipal(member.getId(), member.getNickname(), "", Collections.emptySet());
+        return new MemberPrincipal(member.getId(), member.hasProfile(), member.getNickname(), "", Collections.emptySet());
     }
 }

--- a/src/main/java/com/whatpl/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/whatpl/global/security/filter/JwtAuthenticationFilter.java
@@ -1,8 +1,12 @@
 package com.whatpl.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.global.exception.ErrorResponse;
 import com.whatpl.global.jwt.JwtProperties;
 import com.whatpl.global.jwt.JwtService;
+import com.whatpl.global.security.domain.MemberPrincipal;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -11,7 +15,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -40,6 +43,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String jwt = extractToken(request);
         try {
             Authentication authentication = jwtService.resolveToken(jwt);
+            // 인증된 사용자가 프로필을 작성했는지 확인한다.
+            checkHasProfile(request, authentication);
+            // SecurityContext 에 Authentication 저장
             SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
             securityContext.setAuthentication(authentication);
             SecurityContextHolder.setContext(securityContext);
@@ -47,11 +53,35 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             securityContextRepository.saveContext(securityContext, request, response);
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
-            responseError(response, "만료된 토큰입니다.");
+            responseError(response, ErrorCode.EXPIRED_TOKEN);
         } catch (MalformedJwtException e) {
-            responseError(response, "잘못된 형식의 토큰입니다.");
+            responseError(response, ErrorCode.MALFORMED_TOKEN);
         } catch (SignatureException e) {
-            responseError(response, "변조된 토큰입니다.");
+            responseError(response, ErrorCode.INVALID_SIGNATURE);
+        } catch (BizException e) {
+            responseError(response, e.getErrorCode());
+        }
+    }
+
+    /**
+     * 요청메시지의 Authorization 헤더에 token 값이 없을 경우, 토큰 재발급 요청일 경우, Authentication 이 존재할 경우 필터 적용 하지 않는다.
+     */
+    @Override
+    protected boolean shouldNotFilter(@Nonnull HttpServletRequest request) throws ServletException {
+        return isReIssueTokenRequest(request) || !StringUtils.hasText(extractToken(request)) || SecurityContextHolder.getContext().getAuthentication() != null;
+    }
+
+    /**
+     * 인증된 사용자의 프로필 작성 여부 확인
+     * 프로필 필수 정보 입력 요청일 경우 skip
+     */
+    private void checkHasProfile(HttpServletRequest request, Authentication authentication) {
+        if (isRequiredProfileRequest(request) || authentication == null) {
+            return;
+        }
+        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+        if (!principal.getHasProfile()) {
+            throw new BizException(ErrorCode.HAS_NO_PROFILE);
         }
     }
 
@@ -68,28 +98,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private void responseError(HttpServletResponse response, String errorMsg) throws IOException {
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
-        objectMapper.writeValue(response.getWriter(), new Object() {
-            @Getter
-            final String message = errorMsg;
-        });
-    }
-
-    /**
-     * 요청메시지의 Authorization 헤더에 token 값이 없을 경우, 토큰 재발급 요청일 경우 필터 적용 하지 않는다.
-     */
-    @Override
-    protected boolean shouldNotFilter(@Nonnull HttpServletRequest request) throws ServletException {
-        return isReIssueTokenRequest(request) || !StringUtils.hasText(extractToken(request));
-    }
-
     private boolean isReIssueTokenRequest(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
         String method = request.getMethod();
         return ("/token".equals(requestURI) &&
                 HttpMethod.POST.name().equals(method));
+    }
+
+    private boolean isRequiredProfileRequest(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+        return ("/members/required".equals(requestURI) &&
+                HttpMethod.POST.name().equals(method));
+    }
+
+    private void responseError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.displayName());
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/com/whatpl/global/util/FileUtils.java
+++ b/src/main/java/com/whatpl/global/util/FileUtils.java
@@ -1,0 +1,24 @@
+package com.whatpl.global.util;
+
+import org.apache.tika.Tika;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class FileUtils {
+
+    private FileUtils() {
+        throw new IllegalStateException("This is Utility class!");
+    }
+
+    public static String extractMimeType(MultipartFile multipartFile) {
+        try {
+            InputStream inputStream = multipartFile.getInputStream();
+            Tika tika = new Tika();
+            return tika.detect(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/whatpl/global/web/validator/MultipartFileValidator.java
+++ b/src/main/java/com/whatpl/global/web/validator/MultipartFileValidator.java
@@ -1,13 +1,11 @@
 package com.whatpl.global.web.validator;
 
+import com.whatpl.global.util.FileUtils;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import org.apache.tika.Tika;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Set;
 
 import static org.springframework.http.MediaType.*;
@@ -27,16 +25,8 @@ public class MultipartFileValidator implements ConstraintValidator<ValidFile, Mu
     }
 
     private boolean isAllowedType(MultipartFile multipartFile) {
-        boolean result;
-        try {
-            InputStream inputStream = multipartFile.getInputStream();
-            Tika tika = new Tika();
-            String mimeType = tika.detect(inputStream);
-            result = allowedTypes.stream()
-                    .anyMatch(type -> type.equals(mimeType));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return result;
+        String mimeType = FileUtils.extractMimeType(multipartFile);
+        return allowedTypes.stream()
+                .anyMatch(type -> type.equals(mimeType));
     }
 }

--- a/src/main/java/com/whatpl/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/member/controller/MemberController.java
@@ -1,16 +1,16 @@
 package com.whatpl.member.controller;
 
+import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.member.dto.NicknameDuplRequest;
 import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.dto.ProfileRequiredRequest;
 import com.whatpl.member.service.MemberProfileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -24,5 +24,12 @@ public class MemberController {
     public ResponseEntity<NicknameDuplResponse> checkNickname(@Valid @ModelAttribute NicknameDuplRequest request) {
         NicknameDuplResponse response = memberProfileService.nicknameDuplCheck(request.getNickname());
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/required")
+    public ResponseEntity<Void> required(@Valid @RequestBody ProfileRequiredRequest request,
+                                      @AuthenticationPrincipal MemberPrincipal principal) {
+        memberProfileService.updateRequiredProfile(request, principal.getId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whatpl/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.whatpl.member.controller;
+
+import com.whatpl.member.dto.NicknameDuplRequest;
+import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.service.MemberProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberProfileService memberProfileService;
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<NicknameDuplResponse> checkNickname(@Valid @ModelAttribute NicknameDuplRequest request) {
+        NicknameDuplResponse response = memberProfileService.nicknameDuplCheck(request.getNickname());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/Career.java
+++ b/src/main/java/com/whatpl/member/domain/Career.java
@@ -11,24 +11,24 @@ import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
-public enum Skill {
+public enum Career {
 
-    TYPE_SCRIPT("TypeScript"),
-    JAVA("Java"),
-    KOTLIN("Kotlin"),
-    PYTHON("Python"),
-    FIGMA("Figma"),
-    JAVA_SCRIPT("JavaScript"),
-    SQL("SQL");
+    NONE("취업 준비중"),
+    ONE("1년차"),
+    TWO("2년차"),
+    THREE("3년차"),
+    FOUR("4년차"),
+    FIVE("5년차"),
+    SIX("6년차");
 
     @JsonValue
     private final String value;
 
     @JsonCreator
-    public static Skill from(String value) {
-        return Arrays.stream(Skill.values())
-                .filter(skill -> skill.getValue().equals(value))
+    public static Career from(String value) {
+        return Arrays.stream(Career.values())
+                .filter(career -> career.getValue().equals(value))
                 .findFirst()
-                .orElseThrow(() -> new BizException(ErrorCode.SKILL_NOT_VALID));
+                .orElseThrow(() -> new BizException(ErrorCode.CAREER_NOT_VALID));
     }
 }

--- a/src/main/java/com/whatpl/member/domain/Job.java
+++ b/src/main/java/com/whatpl/member/domain/Job.java
@@ -1,0 +1,34 @@
+package com.whatpl.member.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum Job {
+
+    PLANNER("기획자"),
+    DESIGNER("UX/UI 디자이너"),
+    WEB_DEVELOPER("웹 개발자"),
+    MOBILE_DEVELOPER("모바일 개발자"),
+    BACKEND_DEVELOPER("백엔드 개발자"),
+    DEVOPS_DEVELOPER("DevOps 개발자"),
+    DATA_SCIENTIST("데이터 사이언티스트");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static Job from(String value) {
+        return Arrays.stream(Job.values())
+                .filter(job -> job.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.JOB_NOT_VALID));
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/Member.java
+++ b/src/main/java/com/whatpl/member/domain/Member.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
@@ -22,26 +21,16 @@ public class Member extends BaseTimeEntity {
 
     private String socialId;
 
-    @Setter
     private String nickname;
-
-    private String profileImage;
-
-    private Integer career;
-
-    private String githubLink;
 
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
     @Builder
-    public Member(SocialType socialType, String socialId, String nickname, String profileImage, Integer career, String githubLink, MemberStatus status) {
+    public Member(SocialType socialType, String socialId, String nickname, MemberStatus status) {
         this.socialType = socialType;
         this.socialId = socialId;
         this.nickname = nickname;
-        this.profileImage = profileImage;
-        this.career = career;
-        this.githubLink = githubLink;
         this.status = status;
     }
 }

--- a/src/main/java/com/whatpl/member/domain/Member.java
+++ b/src/main/java/com/whatpl/member/domain/Member.java
@@ -2,14 +2,18 @@ package com.whatpl.member.domain;
 
 import com.whatpl.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Getter
-@NoArgsConstructor
 @Entity
-@Table(name = "members")
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -26,11 +30,45 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
+    @Enumerated(EnumType.STRING)
+    private Job job;
+
+    @Enumerated(EnumType.STRING)
+    private Career career;
+
+    private Boolean profileOpen;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<MemberSkill> memberSkills = new HashSet<>();
+
     @Builder
-    public Member(SocialType socialType, String socialId, String nickname, MemberStatus status) {
+    public Member(SocialType socialType, String socialId, String nickname, MemberStatus status, Job job) {
         this.socialType = socialType;
         this.socialId = socialId;
         this.nickname = nickname;
         this.status = status;
+        this.job = job;
+    }
+
+    //==연관관계 메서드==//
+    public void addMemberSkill(MemberSkill memberSkill) {
+        if (memberSkill == null) {
+            return;
+        }
+        this.memberSkills.add(memberSkill);
+        memberSkill.setMember(this);
+    }
+
+
+    //==비즈니스 로직==//
+    /**
+     * 필수 정보 입력
+     */
+    public void modifyRequiredInfo(String nickname, Job job, Career career, boolean profileOpen, Set<MemberSkill> memberSkills) {
+        this.nickname = nickname;
+        this.job = job;
+        this.career = career;
+        this.profileOpen = profileOpen;
+        memberSkills.forEach(this::addMemberSkill);
     }
 }

--- a/src/main/java/com/whatpl/member/domain/Member.java
+++ b/src/main/java/com/whatpl/member/domain/Member.java
@@ -42,12 +42,15 @@ public class Member extends BaseTimeEntity {
     private Set<MemberSkill> memberSkills = new HashSet<>();
 
     @Builder
-    public Member(SocialType socialType, String socialId, String nickname, MemberStatus status, Job job) {
+    public Member(SocialType socialType, String socialId, String nickname, MemberStatus status,
+                  Job job, Career career, Boolean profileOpen) {
         this.socialType = socialType;
         this.socialId = socialId;
         this.nickname = nickname;
         this.status = status;
         this.job = job;
+        this.career = career;
+        this.profileOpen = profileOpen;
     }
 
     //==연관관계 메서드==//

--- a/src/main/java/com/whatpl/member/domain/Member.java
+++ b/src/main/java/com/whatpl/member/domain/Member.java
@@ -6,8 +6,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.CollectionUtils;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 @Getter
@@ -39,7 +40,7 @@ public class Member extends BaseTimeEntity {
     private Boolean profileOpen;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<MemberSkill> memberSkills = new HashSet<>();
+    private Set<MemberSkill> memberSkills = new LinkedHashSet<>();
 
     @Builder
     public Member(SocialType socialType, String socialId, String nickname, MemberStatus status,
@@ -73,5 +74,17 @@ public class Member extends BaseTimeEntity {
         this.career = career;
         this.profileOpen = profileOpen;
         memberSkills.forEach(this::addMemberSkill);
+    }
+
+    /**
+     * 프로필 작성 여부
+     * 필수 정보만 입력하면 작성한 것으로 판단
+     */
+    public boolean hasProfile() {
+        return (!CollectionUtils.isEmpty(memberSkills) &&
+                getJob() != null &&
+                getCareer() != null &&
+                getNickname() != null &&
+                getProfileOpen() != null);
     }
 }

--- a/src/main/java/com/whatpl/member/domain/MemberSkill.java
+++ b/src/main/java/com/whatpl/member/domain/MemberSkill.java
@@ -1,0 +1,30 @@
+package com.whatpl.member.domain;
+
+import com.whatpl.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Table(name = "member_skill")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSkill extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Skill skill;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public MemberSkill(Skill skill, Member member) {
+        this.skill = skill;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/Skill.java
+++ b/src/main/java/com/whatpl/member/domain/Skill.java
@@ -1,0 +1,30 @@
+package com.whatpl.member.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum Skill {
+
+    JAVA("자바!_!"),
+    KOTLIN("코틀린~~"),
+    SPRING("스프링!!");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static Skill from(String value) {
+        return Arrays.stream(Skill.values())
+                .filter(skill -> skill.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.SKILL_NOT_VALID));
+    }
+}

--- a/src/main/java/com/whatpl/member/dto/MemberSkillDto.java
+++ b/src/main/java/com/whatpl/member/dto/MemberSkillDto.java
@@ -1,0 +1,16 @@
+package com.whatpl.member.dto;
+
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.MemberSkill;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberSkillDto {
+
+    private final Member member;
+    private final Set<MemberSkill> memberSkills;
+}

--- a/src/main/java/com/whatpl/member/dto/NicknameDuplRequest.java
+++ b/src/main/java/com/whatpl/member/dto/NicknameDuplRequest.java
@@ -1,0 +1,15 @@
+package com.whatpl.member.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NicknameDuplRequest {
+
+    @NotEmpty(message = "닉네임은 필수 입력값입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,8}$", message = "닉네임은 특수문자를 제외한 2~8자리여야 합니다.")
+    private String nickname;
+}

--- a/src/main/java/com/whatpl/member/dto/NicknameDuplResponse.java
+++ b/src/main/java/com/whatpl/member/dto/NicknameDuplResponse.java
@@ -1,0 +1,28 @@
+package com.whatpl.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NicknameDuplResponse {
+
+    private final boolean success;
+    private final String message;
+
+    @Builder
+    public NicknameDuplResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    public static NicknameDuplResponse of(boolean success, String nickname) {
+        NicknameDuplResponseBuilder builder = NicknameDuplResponse.builder()
+                .success(success);
+        if (success) {
+            builder.message(String.format("사용 가능한 닉네임입니다. %s", nickname));
+        } else {
+            builder.message(String.format("이미 존재하는 닉네임입니다. %s", nickname));
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/com/whatpl/member/dto/ProfileRequiredRequest.java
+++ b/src/main/java/com/whatpl/member/dto/ProfileRequiredRequest.java
@@ -1,0 +1,35 @@
+package com.whatpl.member.dto;
+
+import com.whatpl.member.domain.Career;
+import com.whatpl.member.domain.Job;
+import com.whatpl.member.domain.Skill;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProfileRequiredRequest {
+
+    @NotEmpty(message = "닉네임은 필수 입력 항목입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,8}$", message = "닉네임은 특수문자를 제외한 2~8자리여야 합니다.")
+    private String nickname;
+
+    @NotNull(message = "직무는 필수 입력 항목입니다.")
+    private Job job;
+
+    @NotNull(message = "경력은 필수 입력 항목입니다.")
+    private Career career;
+
+    @NotNull(message = "기술스택은 필수 입력 항목입니다.")
+    @NotEmpty(message = "기술스택은 필수 입력 항목입니다.")
+    private Set<Skill> skills;
+
+    private boolean profileOpen;
+}

--- a/src/main/java/com/whatpl/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/whatpl/member/repository/MemberQueryRepository.java
@@ -1,0 +1,13 @@
+package com.whatpl.member.repository;
+
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.SocialType;
+
+import java.util.Optional;
+
+public interface MemberQueryRepository {
+
+    Optional<Member> findMemberWithAllById(long id);
+
+    Optional<Member> findMemberWithAllBySocialTypeId(SocialType socialType, String socialId);
+}

--- a/src/main/java/com/whatpl/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/member/repository/MemberQueryRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.whatpl.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.SocialType;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.whatpl.member.domain.QMember.member;
+import static com.whatpl.member.domain.QMemberSkill.memberSkill;
+
+@RequiredArgsConstructor
+public class MemberQueryRepositoryImpl implements MemberQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Member> findMemberWithAllById(long id) {
+        Member result = queryFactory.selectFrom(member)
+                .join(member.memberSkills, memberSkill).fetchJoin()
+                .where(member.id.eq(id))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Optional<Member> findMemberWithAllBySocialTypeId(SocialType socialType, String socialId) {
+        Member result = queryFactory.selectFrom(member)
+                .join(member.memberSkills, memberSkill).fetchJoin()
+                .where(member.socialType.eq(socialType), member.socialId.eq(socialId))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/whatpl/member/repository/MemberRepository.java
+++ b/src/main/java/com/whatpl/member/repository/MemberRepository.java
@@ -1,13 +1,10 @@
 package com.whatpl.member.repository;
 
 import com.whatpl.member.domain.Member;
-import com.whatpl.member.domain.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
-
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository{
     Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/whatpl/member/repository/MemberRepository.java
+++ b/src/main/java/com/whatpl/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/whatpl/member/repository/MemberSkillRepository.java
+++ b/src/main/java/com/whatpl/member/repository/MemberSkillRepository.java
@@ -1,0 +1,13 @@
+package com.whatpl.member.repository;
+
+import com.whatpl.member.domain.MemberSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from MemberSkill ms where ms.member.id = :memberId")
+    void deleteByMemberId(long memberId);
+}

--- a/src/main/java/com/whatpl/member/service/MemberLoginService.java
+++ b/src/main/java/com/whatpl/member/service/MemberLoginService.java
@@ -18,7 +18,6 @@ public class MemberLoginService {
 
     private Member createMember(OAuth2UserInfo oAuth2UserInfo) {
         Member member = Member.builder()
-                .nickname(oAuth2UserInfo.getName())
                 .socialType(SocialType.valueOf(oAuth2UserInfo.getRegistrationId().toUpperCase()))
                 .socialId(oAuth2UserInfo.getProviderId())
                 .status(MemberStatus.ACTIVE)

--- a/src/main/java/com/whatpl/member/service/MemberLoginService.java
+++ b/src/main/java/com/whatpl/member/service/MemberLoginService.java
@@ -28,7 +28,7 @@ public class MemberLoginService {
 
     @Transactional
     public MemberPrincipal getOrCreateMember(OAuth2UserInfo oAuth2UserInfo) {
-        Member member = memberRepository.findBySocialTypeAndSocialId(
+        Member member = memberRepository.findMemberWithAllBySocialTypeId(
                         SocialType.valueOf(oAuth2UserInfo.getRegistrationId().toUpperCase()),
                         oAuth2UserInfo.getProviderId())
                 .orElseGet(() -> createMember(oAuth2UserInfo));

--- a/src/main/java/com/whatpl/member/service/MemberLoginService.java
+++ b/src/main/java/com/whatpl/member/service/MemberLoginService.java
@@ -18,6 +18,7 @@ public class MemberLoginService {
 
     private Member createMember(OAuth2UserInfo oAuth2UserInfo) {
         Member member = Member.builder()
+                .nickname(oAuth2UserInfo.getName())
                 .socialType(SocialType.valueOf(oAuth2UserInfo.getRegistrationId().toUpperCase()))
                 .socialId(oAuth2UserInfo.getProviderId())
                 .status(MemberStatus.ACTIVE)
@@ -32,6 +33,6 @@ public class MemberLoginService {
                         oAuth2UserInfo.getProviderId())
                 .orElseGet(() -> createMember(oAuth2UserInfo));
 
-        return MemberPrincipal.of(member);
+        return MemberPrincipal.from(member);
     }
 }

--- a/src/main/java/com/whatpl/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/member/service/MemberProfileService.java
@@ -1,0 +1,25 @@
+package com.whatpl.member.service;
+
+import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@RequiredArgsConstructor
+public class MemberProfileService {
+
+    private final MemberRepository memberRepository;
+
+    public NicknameDuplResponse nicknameDuplCheck(final String nickname) {
+        AtomicReference<NicknameDuplResponse> result = new AtomicReference<>();
+        memberRepository.findByNickname(nickname)
+                .ifPresentOrElse(
+                        member -> result.set(NicknameDuplResponse.of(false, nickname)),
+                        () -> result.set(NicknameDuplResponse.of(true, nickname))
+                );
+        return result.get();
+    }
+}

--- a/src/main/java/com/whatpl/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/member/service/MemberProfileService.java
@@ -1,10 +1,16 @@
 package com.whatpl.member.service;
 
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.MemberSkill;
+import com.whatpl.member.dto.MemberSkillDto;
 import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.dto.ProfileRequiredRequest;
 import com.whatpl.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Service
@@ -12,7 +18,9 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MemberProfileService {
 
     private final MemberRepository memberRepository;
+    private final MemberSkillService memberSkillService;
 
+    @Transactional(readOnly = true)
     public NicknameDuplResponse nicknameDuplCheck(final String nickname) {
         AtomicReference<NicknameDuplResponse> result = new AtomicReference<>();
         memberRepository.findByNickname(nickname)
@@ -21,5 +29,15 @@ public class MemberProfileService {
                         () -> result.set(NicknameDuplResponse.of(true, nickname))
                 );
         return result.get();
+    }
+
+    @Transactional
+    public void updateRequiredProfile(final ProfileRequiredRequest request, final long memberId) {
+        MemberSkillDto memberSkillDto = memberSkillService.updateMemberSkills(request.getSkills(), memberId);
+        Member member = memberSkillDto.getMember();
+        Set<MemberSkill> memberSkills = memberSkillDto.getMemberSkills();
+
+        member.modifyRequiredInfo(request.getNickname(), request.getJob(),
+                request.getCareer(), request.isProfileOpen(), memberSkills);
     }
 }

--- a/src/main/java/com/whatpl/member/service/MemberSkillService.java
+++ b/src/main/java/com/whatpl/member/service/MemberSkillService.java
@@ -1,0 +1,41 @@
+package com.whatpl.member.service;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.MemberSkill;
+import com.whatpl.member.domain.Skill;
+import com.whatpl.member.dto.MemberSkillDto;
+import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.member.repository.MemberSkillRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemberSkillService {
+
+    private final MemberRepository memberRepository;
+    private final MemberSkillRepository memberSkillRepository;
+
+    @Transactional
+    public MemberSkillDto updateMemberSkills(Set<Skill> skills, long memberId) {
+        // memberId에 매핑되는 memberSkill 데이터를 삭제한다. (벌크연산)
+        memberSkillRepository.deleteByMemberId(memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+
+        Set<MemberSkill> memberSkills = skills.stream()
+                .map(skill -> new MemberSkill(skill, member))
+                .collect(Collectors.toSet());
+
+        // memberSkills 전체 저장한다.
+        memberSkillRepository.saveAll(memberSkills);
+        return new MemberSkillDto(member, memberSkills);
+    }
+}

--- a/src/main/java/com/whatpl/member/service/MemberSkillService.java
+++ b/src/main/java/com/whatpl/member/service/MemberSkillService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,7 +33,7 @@ public class MemberSkillService {
 
         Set<MemberSkill> memberSkills = skills.stream()
                 .map(skill -> new MemberSkill(skill, member))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // memberSkills 전체 저장한다.
         memberSkillRepository.saveAll(memberSkills);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
     hibernate:
       ddl-auto: create
     database: mysql
+    open-in-view: false
 
   data:
     redis:

--- a/src/test/java/com/whatpl/ApiDocTag.java
+++ b/src/test/java/com/whatpl/ApiDocTag.java
@@ -1,0 +1,13 @@
+package com.whatpl;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApiDocTag {
+
+    MEMBER("Members");
+
+    private final String tag;
+}

--- a/src/test/java/com/whatpl/ApiDocUtils.java
+++ b/src/test/java/com/whatpl/ApiDocUtils.java
@@ -1,0 +1,34 @@
+package com.whatpl;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class ApiDocUtils {
+
+    private ApiDocUtils() {
+        throw new IllegalStateException("This is utility class!");
+    }
+
+    public static List<FieldDescriptor> buildDetailErrorResponseFields() {
+        return List.of(
+                fieldWithPath("code").type(JsonFieldType.STRING)
+                        .description("에러코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                        .description("상태코드"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                        .description("에러 메시지"),
+                fieldWithPath("detailErrors").type(JsonFieldType.ARRAY)
+                        .description("에러 상세 메시지"),
+                fieldWithPath("detailErrors[].field").type(JsonFieldType.STRING)
+                        .description("요청 필드"),
+                fieldWithPath("detailErrors[].value").type(JsonFieldType.STRING)
+                        .description("요청 값"),
+                fieldWithPath("detailErrors[].reason").type(JsonFieldType.STRING)
+                        .description("에러 사유")
+        );
+    }
+}

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -1,16 +1,20 @@
 package com.whatpl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whatpl.attachment.service.AttachmentService;
 import com.whatpl.global.config.SecurityConfig;
 import com.whatpl.global.jwt.JwtProperties;
 import com.whatpl.global.jwt.JwtService;
 import com.whatpl.member.service.MemberLoginService;
 import com.whatpl.member.service.MemberProfileService;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
 
 @WebMvcTest
 @Import(SecurityConfig.class)
@@ -18,6 +22,9 @@ public class BaseSecurityWebMvcTest {
 
     @Autowired
     protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     @MockBean
     protected MemberLoginService memberLoginService;
@@ -33,4 +40,9 @@ public class BaseSecurityWebMvcTest {
 
     @MockBean
     protected MemberProfileService memberProfileService;
+
+    @BeforeEach
+    protected void init() {
+        when(jwtProperties.getTokenType()).thenReturn("Bearer");
+    }
 }

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -5,6 +5,7 @@ import com.whatpl.global.config.SecurityConfig;
 import com.whatpl.global.jwt.JwtProperties;
 import com.whatpl.global.jwt.JwtService;
 import com.whatpl.member.service.MemberLoginService;
+import com.whatpl.member.service.MemberProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -29,4 +30,7 @@ public class BaseSecurityWebMvcTest {
 
     @MockBean
     protected AttachmentService attachmentService;
+
+    @MockBean
+    protected MemberProfileService memberProfileService;
 }

--- a/src/test/java/com/whatpl/WithMockWhatplMember.java
+++ b/src/test/java/com/whatpl/WithMockWhatplMember.java
@@ -1,0 +1,21 @@
+package com.whatpl;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockWhatplMemberSecurityContextFactory.class)
+public @interface WithMockWhatplMember {
+
+    @AliasFor("value")
+    long id() default 0L;
+
+    @AliasFor("id")
+    long value() default 0L;
+}

--- a/src/test/java/com/whatpl/WithMockWhatplMemberSecurityContextFactory.java
+++ b/src/test/java/com/whatpl/WithMockWhatplMemberSecurityContextFactory.java
@@ -1,0 +1,22 @@
+package com.whatpl;
+
+import com.whatpl.global.security.domain.MemberPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Collections;
+
+public class WithMockWhatplMemberSecurityContextFactory implements WithSecurityContextFactory<WithMockWhatplMember> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockWhatplMember whatplMember) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        MemberPrincipal principal = new MemberPrincipal(whatplMember.id(), "왓플테스트유저", "", Collections.emptySet());
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/src/test/java/com/whatpl/attachment/docs/AttachmentDocsTest.java
+++ b/src/test/java/com/whatpl/attachment/docs/AttachmentDocsTest.java
@@ -2,6 +2,7 @@ package com.whatpl.attachment.docs;
 
 import com.whatpl.BaseSecurityWebMvcTest;
 import com.whatpl.attachment.dto.ResourceDto;
+import com.whatpl.global.security.model.WithMockWhatplMember;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.DisplayName;
@@ -39,13 +40,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
 
     @Test
-    @WithMockUser
+    @WithMockWhatplMember
     @DisplayName("첨부파일 업로드 API Docs")
     void upload() throws Exception {
         // given
         String filename = "cat.jpg";
         MockMultipartFile multipartFile = createMockMultipartFile(filename, IMAGE_JPEG_VALUE);
-        when(jwtProperties.getTokenType()).thenReturn("Bearer");
 
         // expected
         mockMvc.perform(multipart("/attachments")
@@ -87,7 +87,6 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
     void upload_fail() throws Exception {
         // given
         MockMultipartFile multipartFile = createMockMultipartFile("fail.docx", "application/docx");
-        when(jwtProperties.getTokenType()).thenReturn("Bearer");
 
         // expected
         mockMvc.perform(multipart("/attachments")

--- a/src/test/java/com/whatpl/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/whatpl/global/security/filter/JwtAuthenticationFilterTest.java
@@ -25,7 +25,7 @@ class JwtAuthenticationFilterTest extends BaseSecurityWebMvcTest {
         // given: 토큰이 유효한 경우로 세팅
         String tokenType = "Bearer";
         String validToken = "validToken";
-        var principal = new MemberPrincipal(1L, "test", "", Collections.emptySet(), null);
+        var principal = new MemberPrincipal(1L, "test", "", Collections.emptySet());
         var authenticationToken = new UsernamePasswordAuthenticationToken(principal, "", Collections.emptySet());
         when(jwtProperties.getTokenType())
                 .thenReturn(tokenType);

--- a/src/test/java/com/whatpl/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/whatpl/global/security/filter/JwtAuthenticationFilterTest.java
@@ -25,16 +25,14 @@ class JwtAuthenticationFilterTest extends BaseSecurityWebMvcTest {
         // given: 토큰이 유효한 경우로 세팅
         String tokenType = "Bearer";
         String validToken = "validToken";
-        var principal = new MemberPrincipal(1L, "test", "", Collections.emptySet());
+        var principal = new MemberPrincipal(1L, true, "test", "", Collections.emptySet());
         var authenticationToken = new UsernamePasswordAuthenticationToken(principal, "", Collections.emptySet());
-        when(jwtProperties.getTokenType())
-                .thenReturn(tokenType);
         when(jwtService.resolveToken(any()))
                 .thenReturn(authenticationToken);
 
         // expected
         mockMvc.perform(get("/")
-                        .header(HttpHeaders.AUTHORIZATION, tokenType + validToken))
+                        .header(HttpHeaders.AUTHORIZATION, tokenType + " " + validToken))
                 .andExpect(SecurityMockMvcResultMatchers.authenticated())
                 .andDo(print());
     }
@@ -44,12 +42,10 @@ class JwtAuthenticationFilterTest extends BaseSecurityWebMvcTest {
     @ValueSource(strings = {"", "Bearer", "Basic", "Basic testToken"})
     void test(String tokenType) throws Exception {
         String invalidToken = "invalidToken";
-        when(jwtProperties.getTokenType())
-                .thenReturn(tokenType);
 
         // expected
         mockMvc.perform(get("/")
-                        .header(HttpHeaders.AUTHORIZATION, tokenType + invalidToken))
+                        .header(HttpHeaders.AUTHORIZATION, tokenType + " " + invalidToken))
                 .andExpect(SecurityMockMvcResultMatchers.unauthenticated())
                 .andDo(print());
     }

--- a/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
+++ b/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
@@ -51,7 +51,7 @@ class JwtServiceTest {
     @DisplayName("accessToken 을 발급한다.")
     void createAccessToken() {
         // given
-        MemberPrincipal principal = new MemberPrincipal(1L, "testuser", "", Collections.emptySet());
+        MemberPrincipal principal = new MemberPrincipal(1L, false, "testuser", "", Collections.emptySet());
         OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(principal, null, "test");
 
         when(jwtProperties.getAccessExpirationTime())
@@ -166,9 +166,9 @@ class JwtServiceTest {
         Member testMember = Member.builder()
                 .nickname("testMember")
                 .build();
-        when(memberRepository.findById(memberId))
+        when(memberRepository.findMemberWithAllById(memberId))
                 .thenReturn(Optional.of(testMember));
-        MemberPrincipal expectedPrincipal = new MemberPrincipal(memberId, testMember.getNickname(), "", Collections.emptySet());
+        MemberPrincipal expectedPrincipal = new MemberPrincipal(memberId, false, testMember.getNickname(), "", Collections.emptySet());
         MockedStatic<MemberPrincipal> memberPrincipalMock = mockStatic(MemberPrincipal.class);
         memberPrincipalMock.when(() -> MemberPrincipal.from(testMember))
                 .thenReturn(expectedPrincipal);

--- a/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
+++ b/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
@@ -7,7 +7,6 @@ import com.whatpl.global.jwt.JwtResponse;
 import com.whatpl.global.jwt.JwtService;
 import com.whatpl.global.redis.RedisService;
 import com.whatpl.global.security.domain.MemberPrincipal;
-import com.whatpl.global.security.domain.OAuth2UserInfo;
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.repository.MemberRepository;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -52,10 +51,7 @@ class JwtServiceTest {
     @DisplayName("accessToken 을 발급한다.")
     void createAccessToken() {
         // given
-        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.builder()
-                .name("testuser")
-                .build();
-        MemberPrincipal principal = new MemberPrincipal(1L, "testuser", "", Collections.emptySet(), oAuth2UserInfo);
+        MemberPrincipal principal = new MemberPrincipal(1L, "testuser", "", Collections.emptySet());
         OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(principal, null, "test");
 
         when(jwtProperties.getAccessExpirationTime())
@@ -172,9 +168,9 @@ class JwtServiceTest {
                 .build();
         when(memberRepository.findById(memberId))
                 .thenReturn(Optional.of(testMember));
-        MemberPrincipal expectedPrincipal = new MemberPrincipal(memberId, testMember.getNickname(), "", Collections.emptySet(), null);
+        MemberPrincipal expectedPrincipal = new MemberPrincipal(memberId, testMember.getNickname(), "", Collections.emptySet());
         MockedStatic<MemberPrincipal> memberPrincipalMock = mockStatic(MemberPrincipal.class);
-        memberPrincipalMock.when(() -> MemberPrincipal.of(testMember))
+        memberPrincipalMock.when(() -> MemberPrincipal.from(testMember))
                 .thenReturn(expectedPrincipal);
         when(jwtProperties.getSecretKey())
                 .thenReturn(Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(MOCK_JWT_SECRET)));

--- a/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
+++ b/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
@@ -77,7 +77,7 @@ class JwtServiceTest {
         // given
         long id = 1L;
         long refreshTokenExpirationTime = 60_000L;
-        String prefix = "refreshToken::";
+        String prefix = "refreshToken:";
         when(jwtProperties.getRefreshExpirationTime())
                 .thenReturn(refreshTokenExpirationTime);
 

--- a/src/test/java/com/whatpl/global/security/model/WithMockWhatplMember.java
+++ b/src/test/java/com/whatpl/global/security/model/WithMockWhatplMember.java
@@ -16,6 +16,8 @@ public @interface WithMockWhatplMember {
     @AliasFor("value")
     long id() default 0L;
 
+    boolean hasProfile() default true;
+
     @AliasFor("id")
     long value() default 0L;
 }

--- a/src/test/java/com/whatpl/global/security/model/WithMockWhatplMember.java
+++ b/src/test/java/com/whatpl/global/security/model/WithMockWhatplMember.java
@@ -1,4 +1,4 @@
-package com.whatpl;
+package com.whatpl.global.security.model;
 
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.security.test.context.support.WithSecurityContext;

--- a/src/test/java/com/whatpl/global/security/model/WithMockWhatplMemberSecurityContextFactory.java
+++ b/src/test/java/com/whatpl/global/security/model/WithMockWhatplMemberSecurityContextFactory.java
@@ -14,7 +14,7 @@ public class WithMockWhatplMemberSecurityContextFactory implements WithSecurityC
     @Override
     public SecurityContext createSecurityContext(WithMockWhatplMember whatplMember) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        MemberPrincipal principal = new MemberPrincipal(whatplMember.id(), "왓플테스트유저", "", Collections.emptySet());
+        MemberPrincipal principal = new MemberPrincipal(whatplMember.id(), whatplMember.hasProfile(), "왓플테스트유저", "", Collections.emptySet());
         Authentication auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
         context.setAuthentication(auth);
         return context;

--- a/src/test/java/com/whatpl/global/security/model/WithMockWhatplMemberSecurityContextFactory.java
+++ b/src/test/java/com/whatpl/global/security/model/WithMockWhatplMemberSecurityContextFactory.java
@@ -1,4 +1,4 @@
-package com.whatpl;
+package com.whatpl.global.security.model;
 
 import com.whatpl.global.security.domain.MemberPrincipal;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/src/test/java/com/whatpl/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/whatpl/member/controller/MemberControllerTest.java
@@ -3,7 +3,7 @@ package com.whatpl.member.controller;
 import com.whatpl.ApiDocTag;
 import com.whatpl.ApiDocUtils;
 import com.whatpl.BaseSecurityWebMvcTest;
-import com.whatpl.WithMockWhatplMember;
+import com.whatpl.global.security.model.WithMockWhatplMember;
 import com.whatpl.member.domain.Career;
 import com.whatpl.member.domain.Job;
 import com.whatpl.member.domain.Skill;

--- a/src/test/java/com/whatpl/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/whatpl/member/controller/MemberControllerTest.java
@@ -1,0 +1,109 @@
+package com.whatpl.member.controller;
+
+import com.whatpl.ApiDocTag;
+import com.whatpl.ApiDocUtils;
+import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.member.dto.NicknameDuplResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+class MemberControllerTest extends BaseSecurityWebMvcTest {
+
+    @Test
+    @WithMockUser
+    @DisplayName("닉네임 중복 확인 API Docs")
+    void checkNickname() throws Exception {
+        // given
+        String nickname = "신제우";
+        NicknameDuplResponse nicknameDuplResponse = NicknameDuplResponse.of(true, nickname);
+        when(memberProfileService.nicknameDuplCheck(nickname))
+                .thenReturn(nicknameDuplResponse);
+        when(jwtProperties.getTokenType()).thenReturn("Bearer");
+
+        // expected
+        mockMvc.perform(get("/members/check-nickname")
+                        .param("nickname", nickname)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}")
+                )
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.success").value(true)
+                )
+                .andDo(print())
+                .andDo(document("check-nickname-dupl",
+                        resourceDetails().tag(ApiDocTag.MEMBER.getTag())
+                                .summary("닉네임 중복 체크"),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        queryParameters(
+                                parameterWithName("nickname").description("닉네임, 2~8글자 한글/영문/숫자")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("사용 가능 여부"),
+                                fieldWithPath("message").description("메시지")
+                        )
+                ));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", "1", "123456789", "특수문자@@"})
+    @WithMockUser
+    @DisplayName("닉네임 중복 확인 API Docs - 닉네임 validation 실패")
+    void checkNickname_fail(String nickname) throws Exception {
+        // given
+        NicknameDuplResponse nicknameDuplResponse = NicknameDuplResponse.of(true, nickname);
+        when(memberProfileService.nicknameDuplCheck(nickname))
+                .thenReturn(nicknameDuplResponse);
+        when(jwtProperties.getTokenType()).thenReturn("Bearer");
+
+        // expected
+        mockMvc.perform(get("/members/check-nickname")
+                        .param("nickname", nickname)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}")
+                )
+                .andExpectAll(
+                        status().isBadRequest(),
+                        jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name())
+                )
+                .andDo(print())
+                .andDo(document("check-nickname-dupl-fail",
+                        resourceDetails().tag(ApiDocTag.MEMBER.getTag())
+                                .summary("닉네임 중복 체크 실패"),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        queryParameters(
+                                parameterWithName("nickname").description("닉네임, 2~8글자 한글/영문/숫자")
+                        ),
+                        responseFields(
+                                ApiDocUtils.buildDetailErrorResponseFields()
+                        )
+                ));
+    }
+
+}

--- a/src/test/java/com/whatpl/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/whatpl/member/controller/MemberControllerTest.java
@@ -3,7 +3,12 @@ package com.whatpl.member.controller;
 import com.whatpl.ApiDocTag;
 import com.whatpl.ApiDocUtils;
 import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.WithMockWhatplMember;
+import com.whatpl.member.domain.Career;
+import com.whatpl.member.domain.Job;
+import com.whatpl.member.domain.Skill;
 import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.dto.ProfileRequiredRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,17 +17,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Set;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -42,7 +53,6 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
         NicknameDuplResponse nicknameDuplResponse = NicknameDuplResponse.of(true, nickname);
         when(memberProfileService.nicknameDuplCheck(nickname))
                 .thenReturn(nicknameDuplResponse);
-        when(jwtProperties.getTokenType()).thenReturn("Bearer");
 
         // expected
         mockMvc.perform(get("/members/check-nickname")
@@ -64,8 +74,8 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
                                 parameterWithName("nickname").description("닉네임, 2~8글자 한글/영문/숫자")
                         ),
                         responseFields(
-                                fieldWithPath("success").description("사용 가능 여부"),
-                                fieldWithPath("message").description("메시지")
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("사용 가능 여부"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("메시지")
                         )
                 ));
     }
@@ -79,7 +89,6 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
         NicknameDuplResponse nicknameDuplResponse = NicknameDuplResponse.of(true, nickname);
         when(memberProfileService.nicknameDuplCheck(nickname))
                 .thenReturn(nicknameDuplResponse);
-        when(jwtProperties.getTokenType()).thenReturn("Bearer");
 
         // expected
         mockMvc.perform(get("/members/check-nickname")
@@ -106,4 +115,40 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
                 ));
     }
 
+    @Test
+    @WithMockWhatplMember(2L)
+    @DisplayName("프로필 필수 정보 입력 API Docs")
+    void required() throws Exception {
+        // given
+        ProfileRequiredRequest request = ProfileRequiredRequest.builder()
+                .nickname("닉네임")
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.THREE)
+                .skills(Set.of(Skill.JAVA, Skill.SQL))
+                .profileOpen(true)
+                .build();
+        doNothing().when(memberProfileService).updateRequiredProfile(any(ProfileRequiredRequest.class), any(Long.class));
+
+        // expected
+        mockMvc.perform(post("/members/required")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("required",
+                        resourceDetails().tag(ApiDocTag.MEMBER.getTag())
+                                .summary("프로필 필수 정보 입력"),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        requestFields(
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                fieldWithPath("career").type(JsonFieldType.STRING).description("경력"),
+                                fieldWithPath("job").type(JsonFieldType.STRING).description("직무"),
+                                fieldWithPath("skills").type(JsonFieldType.ARRAY).description("기술스택"),
+                                fieldWithPath("profileOpen").type(JsonFieldType.BOOLEAN).description("프로필 공개 여부 [기본값=false]").optional()
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/whatpl/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/whatpl/member/service/MemberProfileServiceTest.java
@@ -1,0 +1,58 @@
+package com.whatpl.member.service;
+
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberProfileServiceTest {
+
+    @InjectMocks
+    MemberProfileService memberProfileService;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("닉네임 중복 - 중복일 경우")
+    void nicknameDuplCheck_dupl() {
+        // given
+        String nickname = "신제우";
+        Member member = Member.builder().nickname(nickname).build();
+        when(memberRepository.findByNickname(nickname))
+                .thenReturn(Optional.of(member));
+
+        // when
+        NicknameDuplResponse response = memberProfileService.nicknameDuplCheck(nickname);
+
+        // then
+        assertFalse(response.isSuccess());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 - 중복이 아닐 경우")
+    void nicknameDuplCheck_not_dupl() {
+        // given
+        String nickname = "신제우";
+        when(memberRepository.findByNickname(nickname))
+                .thenReturn(Optional.empty());
+
+        // when
+        NicknameDuplResponse response = memberProfileService.nicknameDuplCheck(nickname);
+
+        // then
+        assertTrue(response.isSuccess());
+    }
+}

--- a/src/test/java/com/whatpl/member/service/MemberSkillServiceTest.java
+++ b/src/test/java/com/whatpl/member/service/MemberSkillServiceTest.java
@@ -13,10 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +36,7 @@ class MemberSkillServiceTest {
     @DisplayName("MemberSkill을 입력한다.")
     void updateMemberSkills() {
         // given
-        Set<Skill> skills = new HashSet<>(Arrays.asList(Skill.JAVA, Skill.PYTHON));
+        Set<Skill> skills = new LinkedHashSet<>(Arrays.asList(Skill.JAVA, Skill.PYTHON));
         Member member = mock(Member.class);
         long memberId = 1L;
         when(member.getId())
@@ -58,7 +55,7 @@ class MemberSkillServiceTest {
         Set<MemberSkill> memberSkills = memberSkillDto.getMemberSkills();
         Set<Skill> resultSkills = memberSkills.stream()
                 .map(MemberSkill::getSkill)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         assertIterableEquals(skills, resultSkills);
         assertEquals(member, memberSkillDto.getMember());
     }

--- a/src/test/java/com/whatpl/member/service/MemberSkillServiceTest.java
+++ b/src/test/java/com/whatpl/member/service/MemberSkillServiceTest.java
@@ -1,0 +1,66 @@
+package com.whatpl.member.service;
+
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.MemberSkill;
+import com.whatpl.member.domain.Skill;
+import com.whatpl.member.dto.MemberSkillDto;
+import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.member.repository.MemberSkillRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberSkillServiceTest {
+
+    @InjectMocks
+    MemberSkillService memberSkillService;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    MemberSkillRepository memberSkillRepository;
+
+    @Test
+    @DisplayName("MemberSkill을 입력한다.")
+    void updateMemberSkills() {
+        // given
+        Set<Skill> skills = new HashSet<>(Arrays.asList(Skill.JAVA, Skill.PYTHON));
+        Member member = mock(Member.class);
+        long memberId = 1L;
+        when(member.getId())
+                .thenReturn(memberId);
+        when(memberRepository.findById(memberId))
+                .thenReturn(Optional.of(member));
+
+        // when
+        MemberSkillDto memberSkillDto = memberSkillService.updateMemberSkills(skills, member.getId());
+
+        // then
+        verify(memberSkillRepository, times(1))
+                .deleteByMemberId(memberId);
+        verify(memberSkillRepository, times(1))
+                .saveAll(any());
+        Set<MemberSkill> memberSkills = memberSkillDto.getMemberSkills();
+        Set<Skill> resultSkills = memberSkills.stream()
+                .map(MemberSkill::getSkill)
+                .collect(Collectors.toSet());
+        assertIterableEquals(skills, resultSkills);
+        assertEquals(member, memberSkillDto.getMember());
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #22 

## 📝작업 내용

- 닉네임 중복체크 기능 구현
  - 유효성 검증은 한글/영문/숫자만 가능하고, 2~8자입니다.
- 프로필 필수 정보 (닉네임, 직무, 경력, 기술 스택, 프로필 공개 여부) 기능 구현
- 프로필 필수 정보를 입력 안한 사용자의 서비스 이용 제한 기능
  - 사용자가 로그인하면 필수 정보 입력 여부를 확인해서 JWT 페이로드의 hpf(hasProfile)클레임에 boolean타입으로 값을 담습니다.
  - JwtAuthenticationFilter에서 JWT페이로드의 hpf클레임을 확인해서 false일 경우 401을 응답합니다.

## 💬리뷰 요구사항(선택)

- SpringSecurity가 인증/인가 관련 로직을 SecurityFilter에서 수행하기 때문에 프로필 입력 안한 사용자도 미인증 사용자라고 생각해서 Filter에 구현했습니다. Interceptor에 구현할까도 고민했었는데, Interceptor는 Handler와 관련 있는 기능을 구현할 때 사용하는게 맞다고 생각했습니다. 혹시 다른 의견 있으시면 코멘트 부탁 드리겠습니다.
