### PR TITLE
Member 프로필 선택 정보 입력

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 	
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc' // restdocs mockmvc
 	testImplementation 'com.epages:restdocs-api-spec-mockmvc:'+restdocsApiSpecVersion // restdocs
+	testImplementation 'com.h2database:h2'
 
 	// SwaggerUI
 	swaggerUI 'org.webjars:swagger-ui:4.11.1'

--- a/src/main/java/com/whatpl/attachment/domain/Attachment.java
+++ b/src/main/java/com/whatpl/attachment/domain/Attachment.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "attachments")
+@Table(name = "attachment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Attachment extends BaseTimeEntity {
 

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     NO_AUTHENTICATION("MBR3", 401, "인증되지 않은 사용자입니다."),
     NO_AUTHORIZATION("MBR4", 403, "접근권한이 없습니다."),
     HAS_NO_PROFILE("MBR5", 401, "프로필이 작성되지 않은 사용자입니다."),
+    MAX_PORTFOLIO_SIZE_EXCEED("MBR6", 400, "포트폴리오는 최대 5개 첨부 가능합니다."),
+    MAX_REFERENCE_SIZE_EXCEED("MBR7", 400, "참고링크는 최대 3개 첨부 가능합니다."),
+    MAX_SUBJECT_SIZE_EXCEED("MBR8", 400, "관심주제는 최대 5개 입력 가능합니다."),
 
     // FILE
     NOT_FOUND_FILE("FILE1", 404, "파일을 찾을 수 없습니다."),
@@ -33,7 +36,10 @@ public enum ErrorCode {
     REQUEST_VALUE_INVALID("CMM5", 400, "입력값이 올바르지 않습니다."),
     SKILL_NOT_VALID("CMM6", 400, "기술스택에 유효하지 않은 값이 존재합니다."),
     JOB_NOT_VALID("CMM7", 400, "직무에 유효하지 않은 값이 존재합니다."),
-    CAREER_NOT_VALID("CMM8", 400, "경력에 유효하지 않은 값이 존재합니다.");
+    CAREER_NOT_VALID("CMM8", 400, "경력에 유효하지 않은 값이 존재합니다."),
+    SUBJECT_NOT_VALID("CMM9", 400, "주제에 유효하지 않은 값이 존재합니다."),
+    WORK_TIME_NOT_VALID("CMM10", 400, "작업시간에 유효하지 않은 값이 존재합니다."),
+    REQUIRED_PARAMETER_MISSING("CMM11", 400, "필수 파라미터가 존재하지 않습니다.");
 
     private final String code;
     private final int status;

--- a/src/main/java/com/whatpl/global/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/whatpl/global/exception/ExceptionControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.List;
@@ -87,5 +88,16 @@ public class ExceptionControllerAdvice {
             return handleException(e);
         }
         return handleBizException(bizException);
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+        ErrorCode requiredParameterMissing = ErrorCode.REQUIRED_PARAMETER_MISSING;
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(requiredParameterMissing.getCode())
+                .message(String.format("%s {%s}", requiredParameterMissing.getMessage(), e.getRequestPartName()))
+                .status(requiredParameterMissing.getStatus())
+                .build();
+        return new ResponseEntity<>(errorResponse, errorResponse.getStatus());
     }
 }

--- a/src/main/java/com/whatpl/global/jwt/JwtService.java
+++ b/src/main/java/com/whatpl/global/jwt/JwtService.java
@@ -112,7 +112,7 @@ public class JwtService {
     private MemberPrincipal getMemberPrincipal(Jws<Claims> claims) {
         long id = Long.parseLong(claims.getPayload().getSubject());
         String nickname = claims.getPayload().get(WhatplClaim.NICKNAME.getKey()).toString();
-        boolean hasProfile = Boolean.getBoolean(claims.getPayload().get(WhatplClaim.HAS_PROFILE.getKey()).toString());
+        boolean hasProfile = Boolean.parseBoolean(claims.getPayload().get(WhatplClaim.HAS_PROFILE.getKey()).toString());
         return new MemberPrincipal(id, hasProfile, nickname, "", Collections.emptySet());
     }
 

--- a/src/main/java/com/whatpl/global/listener/InitDataLoader.java
+++ b/src/main/java/com/whatpl/global/listener/InitDataLoader.java
@@ -1,0 +1,56 @@
+package com.whatpl.global.listener;
+
+import com.whatpl.member.domain.*;
+import com.whatpl.member.repository.MemberRepository;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InitDataLoader implements ApplicationListener<ApplicationReadyEvent> {
+
+    private static final AtomicLong memberCount = new AtomicLong(0L);
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public void onApplicationEvent(@Nonnull ApplicationReadyEvent event) {
+        log.info("===== Application 로딩 후 DATA 초기화 작업을 시작합니다. =====");
+        setupInitMembers();
+        log.info("===== Application 로딩 후 DATA 초기화 작업을 종료합니다. =====");
+    }
+
+    private void setupInitMembers() {
+        createMemberIfNotFound(Set.of(Skill.JAVA, Skill.SQL));
+        createMemberIfNotFound(Set.of(Skill.FIGMA, Skill.KOTLIN));
+    }
+
+    /**
+     * 필수정보 입력된 사용자 생성
+     */
+    private void createMemberIfNotFound(Set<Skill> skills) {
+        SocialType fixedSocialType = SocialType.NAVER;
+        String fixedNickname = "왓플테스트멤버" + memberCount.incrementAndGet();
+        Member member = memberRepository.findMemberWithAllBySocialTypeId(fixedSocialType, fixedNickname)
+                .orElseGet(() -> Member.builder()
+                        .nickname(fixedNickname)
+                        .job(Job.BACKEND_DEVELOPER)
+                        .career(Career.NONE)
+                        .workTime(WorkTime.LESS_THAN_TEN)
+                        .socialType(fixedSocialType)
+                        .socialId(fixedNickname)
+                        .profileOpen(false)
+                        .build());
+        member.modifyMemberSkills(skills);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/whatpl/global/web/validator/MultipartFileListValidator.java
+++ b/src/main/java/com/whatpl/global/web/validator/MultipartFileListValidator.java
@@ -1,0 +1,25 @@
+package com.whatpl.global.web.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public class MultipartFileListValidator implements ConstraintValidator<ValidFileList, List<MultipartFile>> {
+
+    @Override
+    public boolean isValid(List<MultipartFile> multipartFileList, ConstraintValidatorContext context) {
+        if (CollectionUtils.isEmpty(multipartFileList)) {
+            return true;
+        }
+        MultipartFileValidator multipartFileValidator = new MultipartFileValidator();
+        for (MultipartFile multipartFile : multipartFileList) {
+            if (!multipartFileValidator.isValid(multipartFile, context)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/whatpl/global/web/validator/ValidFileList.java
+++ b/src/main/java/com/whatpl/global/web/validator/ValidFileList.java
@@ -1,0 +1,21 @@
+package com.whatpl.global.web.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = {ElementType.PARAMETER, ElementType.FIELD})
+@Retention(value = RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MultipartFileListValidator.class)
+public @interface ValidFileList {
+
+    String message() default "허용된 확장자가 아닙니다. [jpg, jpeg, png, gif, pdf]";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/src/main/java/com/whatpl/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/member/controller/MemberController.java
@@ -1,18 +1,24 @@
 package com.whatpl.member.controller;
 
 import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.global.web.validator.ValidFileList;
 import com.whatpl.member.dto.NicknameDuplRequest;
 import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.dto.ProfileOptionalRequest;
 import com.whatpl.member.dto.ProfileRequiredRequest;
 import com.whatpl.member.service.MemberProfileService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
-@Slf4j
+import java.util.List;
+
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
@@ -28,8 +34,18 @@ public class MemberController {
 
     @PostMapping("/required")
     public ResponseEntity<Void> required(@Valid @RequestBody ProfileRequiredRequest request,
-                                      @AuthenticationPrincipal MemberPrincipal principal) {
+                                         @AuthenticationPrincipal MemberPrincipal principal) {
         memberProfileService.updateRequiredProfile(request, principal.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/optional")
+    public ResponseEntity<Void> optional(@Valid @RequestPart ProfileOptionalRequest info,
+                                         @Size(max = 5, message = "포트폴리오는 최대 5개 첨부 가능합니다.")
+                                         @ValidFileList(message = "포트폴리오에 허용된 확장자가 아닙니다. [jpg, jpeg, png, gif, pdf]")
+                                         @RequestPart(required = false) List<MultipartFile> portfolios,
+                                         @AuthenticationPrincipal MemberPrincipal principal) {
+        memberProfileService.updateOptionalProfile(info, portfolios, principal.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whatpl/member/domain/MemberPortfolio.java
+++ b/src/main/java/com/whatpl/member/domain/MemberPortfolio.java
@@ -1,0 +1,33 @@
+package com.whatpl.member.domain;
+
+import com.whatpl.attachment.domain.Attachment;
+import com.whatpl.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity
+@Table(name = "member_portfolio")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberPortfolio extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "attachment_id")
+    private Attachment attachment;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public MemberPortfolio(Attachment attachment) {
+        this.attachment = attachment;
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/MemberReference.java
+++ b/src/main/java/com/whatpl/member/domain/MemberReference.java
@@ -1,0 +1,30 @@
+package com.whatpl.member.domain;
+
+import com.whatpl.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity
+@Table(name = "member_reference")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberReference extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String reference;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public MemberReference(String reference) {
+        this.reference = reference;
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/MemberSubject.java
+++ b/src/main/java/com/whatpl/member/domain/MemberSubject.java
@@ -1,0 +1,31 @@
+package com.whatpl.member.domain;
+
+import com.whatpl.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity
+@Table(name = "member_subject")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSubject extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Subject subject;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public MemberSubject(Subject subject) {
+        this.subject = subject;
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/Subject.java
+++ b/src/main/java/com/whatpl/member/domain/Subject.java
@@ -1,0 +1,29 @@
+package com.whatpl.member.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum Subject {
+
+    SOCIAL_MEDIA("소셜 미디어"),
+    HEALTH("건강/운동");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static Subject from(String value) {
+        return Arrays.stream(Subject.values())
+                .filter(subject -> subject.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.SUBJECT_NOT_VALID));
+    }
+}

--- a/src/main/java/com/whatpl/member/domain/WorkTime.java
+++ b/src/main/java/com/whatpl/member/domain/WorkTime.java
@@ -1,0 +1,31 @@
+package com.whatpl.member.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum WorkTime {
+
+    LESS_THAN_TEN("10시간 미만"),
+    TEN_TO_TWENTY("10시간 이상 20시간 미만"),
+    TWENTY_TO_THIRTY("20시간 이상 30시간 미만"),
+    THIRTY_TO_FORTY("30시간 이상 40시간 미만");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static WorkTime from(String value) {
+        return Arrays.stream(WorkTime.values())
+                .filter(workTime -> workTime.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.WORK_TIME_NOT_VALID));
+    }
+}

--- a/src/main/java/com/whatpl/member/dto/ProfileOptionalRequest.java
+++ b/src/main/java/com/whatpl/member/dto/ProfileOptionalRequest.java
@@ -1,0 +1,24 @@
+package com.whatpl.member.dto;
+
+import com.whatpl.member.domain.Subject;
+import com.whatpl.member.domain.WorkTime;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProfileOptionalRequest {
+
+    @Size(max = 5, message = "관심주제는 최대 5개 입력 가능합니다.")
+    private Set<Subject> subjects;
+
+    @Size(max = 3, message = "참고링크는 최대 3개 첨부 가능합니다.")
+    private Set<String> references;
+
+    private WorkTime workTime;
+}

--- a/src/main/java/com/whatpl/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/whatpl/member/repository/MemberQueryRepository.java
@@ -2,6 +2,8 @@ package com.whatpl.member.repository;
 
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.domain.SocialType;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
 
@@ -9,5 +11,6 @@ public interface MemberQueryRepository {
 
     Optional<Member> findMemberWithAllById(long id);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Member> findMemberWithAllBySocialTypeId(SocialType socialType, String socialId);
 }

--- a/src/main/java/com/whatpl/member/repository/MemberQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/member/repository/MemberQueryRepositoryImpl.java
@@ -8,7 +8,10 @@ import lombok.RequiredArgsConstructor;
 import java.util.Optional;
 
 import static com.whatpl.member.domain.QMember.member;
+import static com.whatpl.member.domain.QMemberPortfolio.memberPortfolio;
+import static com.whatpl.member.domain.QMemberReference.memberReference;
 import static com.whatpl.member.domain.QMemberSkill.memberSkill;
+import static com.whatpl.member.domain.QMemberSubject.memberSubject;
 
 @RequiredArgsConstructor
 public class MemberQueryRepositoryImpl implements MemberQueryRepository {
@@ -18,7 +21,10 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
     @Override
     public Optional<Member> findMemberWithAllById(long id) {
         Member result = queryFactory.selectFrom(member)
-                .join(member.memberSkills, memberSkill).fetchJoin()
+                .leftJoin(member.memberSkills, memberSkill).fetchJoin()
+                .leftJoin(member.memberPortfolios, memberPortfolio).fetchJoin()
+                .leftJoin(member.memberReferences, memberReference).fetchJoin()
+                .leftJoin(member.memberSubjects, memberSubject).fetchJoin()
                 .where(member.id.eq(id))
                 .fetchOne();
         return Optional.ofNullable(result);
@@ -27,7 +33,10 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
     @Override
     public Optional<Member> findMemberWithAllBySocialTypeId(SocialType socialType, String socialId) {
         Member result = queryFactory.selectFrom(member)
-                .join(member.memberSkills, memberSkill).fetchJoin()
+                .leftJoin(member.memberSkills, memberSkill).fetchJoin()
+                .leftJoin(member.memberPortfolios, memberPortfolio).fetchJoin()
+                .leftJoin(member.memberReferences, memberReference).fetchJoin()
+                .leftJoin(member.memberSubjects, memberSubject).fetchJoin()
                 .where(member.socialType.eq(socialType), member.socialId.eq(socialId))
                 .fetchOne();
         return Optional.ofNullable(result);

--- a/src/main/java/com/whatpl/member/service/MemberPortfolioService.java
+++ b/src/main/java/com/whatpl/member/service/MemberPortfolioService.java
@@ -1,0 +1,39 @@
+package com.whatpl.member.service;
+
+import com.whatpl.attachment.domain.Attachment;
+import com.whatpl.attachment.service.AttachmentService;
+import com.whatpl.member.domain.MemberPortfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberPortfolioService {
+
+    private final AttachmentService attachmentService;
+
+    @Transactional
+    public List<MemberPortfolio> uploadPortfolio(List<MultipartFile> portfolios) {
+        if (CollectionUtils.isEmpty(portfolios)) {
+            return Collections.emptyList();
+        }
+
+        List<MemberPortfolio> memberPortfolios = new ArrayList<>();
+        portfolios.parallelStream()
+                .forEach(portfolio -> {
+                    Long attachmentId = attachmentService.upload(portfolio);
+                    // 1차 캐시에 있는 데이터 조회 (쿼리X)
+                    Attachment attachment = attachmentService.findById(attachmentId);
+                    MemberPortfolio memberPortfolio = new MemberPortfolio(attachment);
+                    memberPortfolios.add(memberPortfolio);
+                });
+        return memberPortfolios;
+    }
+}

--- a/src/main/java/com/whatpl/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/member/service/MemberProfileService.java
@@ -3,13 +3,18 @@ package com.whatpl.member.service;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.member.domain.Member;
+import com.whatpl.member.domain.MemberPortfolio;
 import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.dto.ProfileOptionalRequest;
 import com.whatpl.member.dto.ProfileRequiredRequest;
 import com.whatpl.member.repository.MemberRepository;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Service
@@ -17,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MemberProfileService {
 
     private final MemberRepository memberRepository;
+    private final MemberPortfolioService memberPortfolioService;
 
     @Transactional(readOnly = true)
     public NicknameDuplResponse nicknameDuplCheck(final String nickname) {
@@ -36,5 +42,16 @@ public class MemberProfileService {
         member.modifyMemberSkills(request.getSkills());
         member.modifyRequiredInfo(request.getNickname(), request.getJob(),
                 request.getCareer(), request.isProfileOpen());
+    }
+
+    @Transactional
+    public void updateOptionalProfile(@NonNull final ProfileOptionalRequest info, final List<MultipartFile> portfolios, final long memberId) {
+        Member member = memberRepository.findMemberWithAllById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        List<MemberPortfolio> memberPortfolios = memberPortfolioService.uploadPortfolio(portfolios);
+        memberPortfolios.forEach(member::addMemberPortfolio);
+        member.modifyMemberSubject(info.getSubjects());
+        member.modifyMemberReference(info.getReferences());
+        member.setWorkTime(info.getWorkTime());
     }
 }

--- a/src/test/java/com/whatpl/BaseRepositoryTest.java
+++ b/src/test/java/com/whatpl/BaseRepositoryTest.java
@@ -1,0 +1,12 @@
+package com.whatpl;
+
+import com.whatpl.global.config.JpaConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+@ActiveProfiles(profiles = "test")
+public abstract class BaseRepositoryTest {
+}

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -12,13 +12,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.when;
 
 @WebMvcTest
 @Import(SecurityConfig.class)
-public class BaseSecurityWebMvcTest {
+public abstract class BaseSecurityWebMvcTest {
 
     @Autowired
     protected MockMvc mockMvc;
@@ -44,5 +50,11 @@ public class BaseSecurityWebMvcTest {
     @BeforeEach
     protected void init() {
         when(jwtProperties.getTokenType()).thenReturn("Bearer");
+    }
+
+    protected MockMultipartFile createMockMultipartFile(String key, String filename, String mimeType) throws IOException {
+        String path = requireNonNull(getClass().getClassLoader().getResource("files/" + filename)).getPath();
+        InputStream inputStream = new FileInputStream(path);
+        return new MockMultipartFile(key, filename, mimeType, inputStream);
     }
 }

--- a/src/test/java/com/whatpl/attachment/controller/AttachmentControllerTest.java
+++ b/src/test/java/com/whatpl/attachment/controller/AttachmentControllerTest.java
@@ -13,12 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.stream.Stream;
 
-import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.MediaType.*;
@@ -35,7 +31,7 @@ class AttachmentControllerTest extends BaseSecurityWebMvcTest {
     @DisplayName("첨부파일 업로드 시 Tika 라이브러리를 이용한 파일 검증이 성공하면 201 응답")
     void upload(String filename, String mimeType) throws Exception {
         // given
-        MockMultipartFile multipartFile = createMockMultipartFile(filename, mimeType);
+        MockMultipartFile multipartFile = createMockMultipartFile("file", filename, mimeType);
 
         // expected
         mockMvc.perform(multipart("/attachments")
@@ -49,7 +45,7 @@ class AttachmentControllerTest extends BaseSecurityWebMvcTest {
     @DisplayName("첨부파일 업로드 시 Tika 라이브러리를 이용한 파일 검증이 실패하면 400 응답")
     void upload_fail(String filename, String mimeType) throws Exception {
         // given
-        MockMultipartFile multipartFile = createMockMultipartFile(filename, mimeType);
+        MockMultipartFile multipartFile = createMockMultipartFile("file", filename, mimeType);
 
         // expected
         mockMvc.perform(multipart("/attachments")
@@ -69,7 +65,7 @@ class AttachmentControllerTest extends BaseSecurityWebMvcTest {
     void download(String filename, String mimeType) throws Exception {
         // given
         long attachmentId = 1L;
-        InputStreamResource resource = new InputStreamResource(createMockMultipartFile(filename, mimeType).getInputStream());
+        InputStreamResource resource = new InputStreamResource(createMockMultipartFile("file", filename, mimeType).getInputStream());
         ResourceDto resourceDto = ResourceDto.builder()
                 .mimeType(mimeType)
                 .resource(resource)
@@ -96,7 +92,7 @@ class AttachmentControllerTest extends BaseSecurityWebMvcTest {
     void preview(String filename, String mimeType) throws Exception {
         // given
         long attachmentId = 1L;
-        InputStreamResource resource = new InputStreamResource(createMockMultipartFile(filename, mimeType).getInputStream());
+        InputStreamResource resource = new InputStreamResource(createMockMultipartFile("file", filename, mimeType).getInputStream());
         ResourceDto resourceDto = ResourceDto.builder()
                 .mimeType(mimeType)
                 .resource(resource)
@@ -110,12 +106,6 @@ class AttachmentControllerTest extends BaseSecurityWebMvcTest {
                 .andExpectAll(
                         status().isOk(),
                         content().contentType(mimeType));
-    }
-
-    private MockMultipartFile createMockMultipartFile(String filename, String mimeType) throws IOException {
-        String path = requireNonNull(getClass().getClassLoader().getResource("files/" + filename)).getPath();
-        InputStream inputStream = new FileInputStream(path);
-        return new MockMultipartFile("file", filename, mimeType, inputStream);
     }
 
     static Stream<Arguments> successParameters() {

--- a/src/test/java/com/whatpl/attachment/docs/AttachmentDocsTest.java
+++ b/src/test/java/com/whatpl/attachment/docs/AttachmentDocsTest.java
@@ -59,9 +59,9 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
 
                                         아래 형식을 참고하여 요청하면 됩니다.
 
-                                        | Content-Disposition   | name   | filename  |Content-Type                 |
-                                        |-----------------------|--------|-----------|-----------------------------|
-                                        | form-data             | file   | 파일명     | MimeType   (ex. image/png)  |
+                                        | name   | filename  |Content-Type                 |
+                                        |--------|-----------|-----------------------------|
+                                        | file   | 파일명     | MimeType   (ex. image/png)  |
                                         """),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION).description("AccessToken"),

--- a/src/test/java/com/whatpl/attachment/docs/AttachmentDocsTest.java
+++ b/src/test/java/com/whatpl/attachment/docs/AttachmentDocsTest.java
@@ -15,13 +15,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
-import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.*;
@@ -45,7 +40,7 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
     void upload() throws Exception {
         // given
         String filename = "cat.jpg";
-        MockMultipartFile multipartFile = createMockMultipartFile(filename, IMAGE_JPEG_VALUE);
+        MockMultipartFile multipartFile = createMockMultipartFile("file", filename, IMAGE_JPEG_VALUE);
 
         // expected
         mockMvc.perform(multipart("/attachments")
@@ -86,7 +81,7 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
     @DisplayName("첨부파일 업로드 API Docs - 허용된 확장자 X")
     void upload_fail() throws Exception {
         // given
-        MockMultipartFile multipartFile = createMockMultipartFile("fail.docx", "application/docx");
+        MockMultipartFile multipartFile = createMockMultipartFile("file", "fail.docx", "application/docx");
 
         // expected
         mockMvc.perform(multipart("/attachments")
@@ -124,7 +119,7 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
         long attachmentId = 1L;
         String filename = "cat.jpg";
         String mimeType = IMAGE_JPEG_VALUE;
-        InputStreamResource resource = new InputStreamResource(createMockMultipartFile(filename, mimeType).getInputStream());
+        InputStreamResource resource = new InputStreamResource(createMockMultipartFile("file", filename, mimeType).getInputStream());
         ResourceDto resourceDto = ResourceDto.builder()
                 .mimeType(mimeType)
                 .resource(resource)
@@ -159,7 +154,7 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
         long attachmentId = 1L;
         String filename = "cat.jpg";
         String mimeType = IMAGE_JPEG_VALUE;
-        InputStreamResource resource = new InputStreamResource(createMockMultipartFile(filename, mimeType).getInputStream());
+        InputStreamResource resource = new InputStreamResource(createMockMultipartFile("file", filename, mimeType).getInputStream());
         ResourceDto resourceDto = ResourceDto.builder()
                 .mimeType(mimeType)
                 .resource(resource)
@@ -179,11 +174,5 @@ public class AttachmentDocsTest extends BaseSecurityWebMvcTest {
                         pathParameters(
                                 parameterWithName("id").description("첨부파일 id")
                         )));
-    }
-
-    private MockMultipartFile createMockMultipartFile(String filename, String mimeType) throws IOException {
-        String path = requireNonNull(getClass().getClassLoader().getResource("files/" + filename)).getPath();
-        InputStream inputStream = new FileInputStream(path);
-        return new MockMultipartFile("file", filename, mimeType, inputStream);
     }
 }

--- a/src/test/java/com/whatpl/member/model/MemberFixture.java
+++ b/src/test/java/com/whatpl/member/model/MemberFixture.java
@@ -31,4 +31,20 @@ public class MemberFixture {
         member.addMemberPortfolio(new MemberPortfolio(attachment));
         return member;
     }
+
+    public static Member onlyRequired() {
+        Member member = Member.builder()
+                .socialType(SocialType.NAVER)
+                .socialId("왓플테스트유저")
+                .nickname("왓플테스트유저")
+                .status(MemberStatus.ACTIVE)
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.NONE)
+                .workTime(WorkTime.LESS_THAN_TEN)
+                .profileOpen(true)
+                .build();
+
+        member.addMemberSkill(new MemberSkill(Skill.JAVA));
+        return member;
+    }
 }

--- a/src/test/java/com/whatpl/member/model/MemberFixture.java
+++ b/src/test/java/com/whatpl/member/model/MemberFixture.java
@@ -1,0 +1,34 @@
+package com.whatpl.member.model;
+
+import com.whatpl.attachment.domain.Attachment;
+import com.whatpl.member.domain.*;
+import org.springframework.http.MediaType;
+
+import java.util.UUID;
+
+public class MemberFixture {
+
+    public static Member withAll() {
+        Member member = Member.builder()
+                .socialType(SocialType.NAVER)
+                .socialId("왓플테스트유저")
+                .nickname("왓플테스트유저")
+                .status(MemberStatus.ACTIVE)
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.NONE)
+                .workTime(WorkTime.LESS_THAN_TEN)
+                .profileOpen(true)
+                .build();
+
+        member.addMemberSkill(new MemberSkill(Skill.JAVA));
+        member.addMemberSubject(new MemberSubject(Subject.HEALTH));
+        member.addMemberReference(new MemberReference("https://github.com"));
+        Attachment attachment = Attachment.builder()
+                .fileName("cat.jpg")
+                .storedName(UUID.randomUUID().toString())
+                .mimeType(MediaType.IMAGE_JPEG_VALUE)
+                .build();
+        member.addMemberPortfolio(new MemberPortfolio(attachment));
+        return member;
+    }
+}

--- a/src/test/java/com/whatpl/member/model/ProfileOptionalRequestFixture.java
+++ b/src/test/java/com/whatpl/member/model/ProfileOptionalRequestFixture.java
@@ -1,0 +1,18 @@
+package com.whatpl.member.model;
+
+import com.whatpl.member.domain.Subject;
+import com.whatpl.member.domain.WorkTime;
+import com.whatpl.member.dto.ProfileOptionalRequest;
+
+import java.util.Set;
+
+public class ProfileOptionalRequestFixture {
+
+    public static ProfileOptionalRequest create() {
+        return ProfileOptionalRequest.builder()
+                .subjects(Set.of(Subject.HEALTH, Subject.SOCIAL_MEDIA))
+                .references(Set.of("https://github.com", "https://https://notefolio.net"))
+                .workTime(WorkTime.THIRTY_TO_FORTY)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/member/repository/MemberQueryRepositoryImplTest.java
+++ b/src/test/java/com/whatpl/member/repository/MemberQueryRepositoryImplTest.java
@@ -1,0 +1,45 @@
+package com.whatpl.member.repository;
+
+import com.whatpl.BaseRepositoryTest;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.model.MemberFixture;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MemberQueryRepositoryImplTest extends BaseRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("Member를 조회할 때 기술스택, 포트폴리오, 참고링크, 관심주제 모두 조회(Fetch Join)")
+    void findMemberWithAllById() {
+        // given
+        Member member = MemberFixture.withAll();
+        Long savedMemberId = memberRepository.save(member).getId();
+        em.flush();
+        em.clear();
+
+        // when
+        Member findMember = memberRepository.findMemberWithAllById(savedMemberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+
+        // then
+        assertEquals(member.getMemberSkills().size(), findMember.getMemberSkills().size());
+        assertEquals(member.getMemberSubjects().size(), findMember.getMemberSubjects().size());
+        assertEquals(member.getMemberReferences().size(), findMember.getMemberReferences().size());
+        assertEquals(member.getMemberPortfolios().size(), findMember.getMemberPortfolios().size());
+        assertNotNull(member.getMemberPortfolios());
+        assertEquals(member, member.getMemberPortfolios().get(0).getMember());
+    }
+}

--- a/src/test/java/com/whatpl/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/whatpl/member/service/MemberProfileServiceTest.java
@@ -1,7 +1,12 @@
 package com.whatpl.member.service;
 
-import com.whatpl.member.domain.Member;
+import com.whatpl.attachment.domain.Attachment;
+import com.whatpl.member.domain.*;
 import com.whatpl.member.dto.NicknameDuplResponse;
+import com.whatpl.member.dto.ProfileOptionalRequest;
+import com.whatpl.member.dto.ProfileRequiredRequest;
+import com.whatpl.member.model.MemberFixture;
+import com.whatpl.member.model.ProfileOptionalRequestFixture;
 import com.whatpl.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,11 +14,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +35,9 @@ class MemberProfileServiceTest {
 
     @Mock
     MemberRepository memberRepository;
+
+    @Mock
+    MemberPortfolioService memberPortfolioService;
 
     @Test
     @DisplayName("닉네임 중복 - 중복일 경우")
@@ -54,5 +68,60 @@ class MemberProfileServiceTest {
 
         // then
         assertTrue(response.isSuccess());
+    }
+
+    @Test
+    @DisplayName("필수정보 입력 시 멤버의 필수정보가 변경된다.")
+    void updateRequiredProfile() {
+        // given
+        Member member = MemberFixture.withAll();
+        when(memberRepository.findMemberWithAllById(any(Long.class)))
+                .thenReturn(Optional.of(member));
+        ProfileRequiredRequest request = ProfileRequiredRequest.builder()
+                .profileOpen(false)
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.FIVE)
+                .skills(Set.of(Skill.PYTHON, Skill.SQL))
+                .build();
+
+        // when
+        memberProfileService.updateRequiredProfile(request, any(Long.class));
+
+        // then
+        assertFalse(member.getProfileOpen());
+        assertEquals(Job.BACKEND_DEVELOPER, member.getJob());
+        assertEquals(Career.FIVE, member.getCareer());
+        assertEquals(2, member.getMemberSkills().size());
+        assertTrue(member.getMemberSkills().stream()
+                .map(MemberSkill::getSkill)
+                .collect(Collectors.toSet())
+                .containsAll(Set.of(Skill.PYTHON, Skill.SQL)));
+    }
+
+    @Test
+    @DisplayName("선택정보 입력 시 멤버의 선택정보가 변경된다.")
+    void updateOptionalProfile() {
+        // given
+        ProfileOptionalRequest request = ProfileOptionalRequestFixture.create();
+        Member member = MemberFixture.onlyRequired();
+        when(memberRepository.findMemberWithAllById(any(Long.class)))
+                .thenReturn(Optional.of(member));
+        List<MultipartFile> portfolios = List.of(
+                new MockMultipartFile("testFile1", "testFile1".getBytes()),
+                new MockMultipartFile("testFile2", "testFile2".getBytes()));
+        when(memberPortfolioService.uploadPortfolio(portfolios))
+                .thenReturn(List.of(
+                        new MemberPortfolio(new Attachment("testFile1", UUID.randomUUID().toString(), "image/jpeg")),
+                        new MemberPortfolio(new Attachment("testFile2", UUID.randomUUID().toString(), "image/png")))
+                );
+
+        // when
+        memberProfileService.updateOptionalProfile(request, portfolios, 0L);
+
+        // then
+        assertEquals(request.getReferences().size(), member.getMemberReferences().size());
+        assertEquals(request.getSubjects().size(), member.getMemberSubjects().size());
+        assertEquals(request.getWorkTime(), member.getWorkTime());
+        assertEquals(portfolios.size(), member.getMemberPortfolios().size());
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+
+  jpa:
+    open-in-view: true
+    hibernate:
+      ddl-auto: create-drop
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+    properties:
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+    database: h2


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

- Member 프로필 선택정보(관심주제, 참고링크, 작업시간, 포트폴리오) 입력 기능
- 생성한 엔티티는 다음과 같습니다.
  - MemberPortfolio : Member - Attachment 연결 엔티티로 Member와는 N:1이고, Attachment와는 1:1입니다.
  - MemberReference: Member의 참고링크 1:N
  - MemberSubject: Member의 관심주제 1:N
- `List<MultipartFile>` 타입 Validation 추가
- Test 환경에서 H2 inmemory DB 사용할 수 있게 세팅 (JPA fetch join 테스트하기 위해 설정했습니다. 추후 필요하시면 코드 참고하셔서 진행하시면 될 것 같습니다. 스프링 test 프로필에서 동작하도록 세팅 되어 있습니다.)
- 포트폴리오 S3 업로드
- ApplicationReadyEvent 발생 시 초기 Member 데이터 insert (테스트용 JWT 생성 및 테스트 편의성을 위해 애플리케이션이 준비되었을 때 초기데이터를 세팅했습니다.)

## 💬리뷰 요구사항(선택)

- Job(직무), Career(경력), Skill(기술스택), Subject(관심주제), WorkTime(작업시간) Enum 타입 도메인들이 Member패키지 안에 있습니다. 해당 도메인들을 추후에 프로젝트나 프로덕트, 왓피플 등의 기능에서 사용하게 될건데 Member패키지에 있는 게 맞나 싶습니다. global패키지나 다른 패키지로 이동시켜야 할 것 같은데, 적절한 패키지 Naming이 있을까요?
