### PR TITLE
프로젝트에 지원하기, 지원서 승인/거절하기

### DIFF
--- a/src/main/java/com/whatpl/global/common/domain/GlobalDomainController.java
+++ b/src/main/java/com/whatpl/global/common/domain/GlobalDomainController.java
@@ -1,6 +1,7 @@
 package com.whatpl.global.common.domain;
 
 import com.whatpl.global.common.domain.enums.*;
+import com.whatpl.project.domain.enums.ApplyStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,12 +29,16 @@ public class GlobalDomainController {
         List<String> workTimes = Arrays.stream(WorkTime.values())
                 .map(WorkTime::getValue)
                 .toList();
+        List<String> applyStatuses = Arrays.stream(ApplyStatus.values())
+                .map(ApplyStatus::getValue)
+                .toList();
         return ResponseEntity.ok(GlobalDomainResponse.builder()
                 .careers(careers)
                 .jobs(jobs)
                 .skills(skills)
                 .subjects(subjects)
                 .workTimes(workTimes)
+                .applyStatuses(applyStatuses)
                 .build());
     }
 }

--- a/src/main/java/com/whatpl/global/common/domain/GlobalDomainResponse.java
+++ b/src/main/java/com/whatpl/global/common/domain/GlobalDomainResponse.java
@@ -15,4 +15,5 @@ public class GlobalDomainResponse {
     private final List<String> skills;
     private final List<String> subjects;
     private final List<String> workTimes;
+    private final List<String> applyStatuses;
 }

--- a/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
@@ -1,0 +1,34 @@
+package com.whatpl.global.config;
+
+
+import com.whatpl.global.security.permission.WhatplPermissionEvaluator;
+import com.whatpl.global.security.permission.manager.ApplyPermissionManager;
+import com.whatpl.global.security.permission.manager.WhatplPermissionManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class MethodSecurityConfig {
+
+    private final ApplyPermissionManager applyPermissionManager;
+
+    @Bean
+    public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
+        Map<String, WhatplPermissionManager> whatplPermissionEvaluatorMap = new HashMap<>();
+        whatplPermissionEvaluatorMap.put("APPLY", applyPermissionManager);
+
+        DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
+        expressionHandler.setPermissionEvaluator(new WhatplPermissionEvaluator(whatplPermissionEvaluatorMap));
+        return expressionHandler;
+    }
+}
+

--- a/src/main/java/com/whatpl/global/config/SecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -26,7 +25,6 @@ import org.springframework.security.web.context.*;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -23,6 +23,15 @@ public enum ErrorCode {
     MAX_REFERENCE_SIZE_EXCEED("MBR7", 400, "참고링크는 최대 3개 첨부 가능합니다."),
     MAX_SUBJECT_SIZE_EXCEED("MBR8", 400, "관심주제는 최대 5개 입력 가능합니다."),
 
+    // PROJECT
+    NOT_FOUND_PROJECT("PRJ1", 404, "프로젝트를 찾을 수 없습니다."),
+    WRITER_NOT_APPLY("PRJ2", 400, "프로젝트 등록자는 본인이 등록한 프로젝트에 지원할 수 없습니다."),
+    NOT_MATCH_APPLY_JOB_WITH_PROJECT("PRJ3", 400, "지원한 직무가 프로젝트 모집직군에 등록되어 있지 않습니다."),
+    RECRUIT_COMPLETED_APPLY_JOB("PRJ4", 400, "지원한 직무는 모집이 완료된 직무입니다."),
+    DUPLICATED_APPLY("PRJ5", 400, "이미 지원한 프로젝트입니다."),
+    COMPLETED_RECRUITMENT("PRJ6", 400, "모집완료된 프로젝트입니다."),
+    DELETED_PROJECT("PRJ7", 400, "삭제된 프로젝트입니다."),
+
     // FILE
     NOT_FOUND_FILE("FILE1", 404, "파일을 찾을 수 없습니다."),
     FILE_SIZE_EXCEED("FILE2", 400, "파일 사이즈를 초과하였습니다."),

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -27,11 +27,13 @@ public enum ErrorCode {
     NOT_FOUND_PROJECT("PRJ1", 404, "프로젝트를 찾을 수 없습니다."),
     WRITER_NOT_APPLY("PRJ2", 400, "프로젝트 등록자는 본인이 등록한 프로젝트에 지원할 수 없습니다."),
     NOT_MATCH_APPLY_JOB_WITH_PROJECT("PRJ3", 400, "지원한 직무가 프로젝트 모집직군에 등록되어 있지 않습니다."),
-    RECRUIT_COMPLETED_APPLY_JOB("PRJ4", 400, "지원한 직무는 모집이 완료된 직무입니다."),
+    RECRUIT_COMPLETED_APPLY_JOB("PRJ4", 400, "해당 직무는 모집이 완료된 직무입니다."),
     DUPLICATED_APPLY("PRJ5", 400, "이미 지원한 프로젝트입니다."),
     COMPLETED_RECRUITMENT("PRJ6", 400, "모집완료된 프로젝트입니다."),
     DELETED_PROJECT("PRJ7", 400, "삭제된 프로젝트입니다."),
     NOT_MATCH_PROJECT_APPLY("PRJ8", 400, "프로젝트 ID와 지원서 ID가 일치하지 않습니다."),
+    ALREADY_PROCESSED_APPLY("PRJ9", 400, "이미 승인 또는 거절된 지원서입니다."),
+    CANT_PROCESS_WAITING("PRJ10", 400, "프로젝트 지원서를 대기 상태로 변경할 수 없습니다."),
 
     // APPLY
     NOT_FOUND_APPLY("APL1", 404, "지원서를 찾을 수 없습니다."),

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     DUPLICATED_APPLY("PRJ5", 400, "이미 지원한 프로젝트입니다."),
     COMPLETED_RECRUITMENT("PRJ6", 400, "모집완료된 프로젝트입니다."),
     DELETED_PROJECT("PRJ7", 400, "삭제된 프로젝트입니다."),
+    NOT_MATCH_PROJECT_APPLY("PRJ8", 400, "프로젝트 ID와 지원서 ID가 일치하지 않습니다."),
 
     // APPLY
     NOT_FOUND_APPLY("APL1", 404, "지원서를 찾을 수 없습니다."),
@@ -58,7 +59,8 @@ public enum ErrorCode {
     SUBJECT_NOT_VALID("DMN4", 400, "주제에 유효하지 않은 값이 존재합니다."),
     WORK_TIME_NOT_VALID("DMN5", 400, "작업시간에 유효하지 않은 값이 존재합니다."),
     UP_DOWN_NOT_VALID("DMN6", 400, "이상/이하에 유효하지 않은 값이 존재합니다."),
-    MEETING_TYPE_NOT_VALID("DMN7", 400, "모임 방식에 유효하지 않은 값이 존재합니다.");
+    MEETING_TYPE_NOT_VALID("DMN7", 400, "모임 방식에 유효하지 않은 값이 존재합니다."),
+    APPLY_STATUS_NOT_VALID("DMN8", 400, "프로젝트 지원 상태에 유효하지 않은 값이 존재합니다.");
 
     private final String code;
     private final int status;

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
     COMPLETED_RECRUITMENT("PRJ6", 400, "모집완료된 프로젝트입니다."),
     DELETED_PROJECT("PRJ7", 400, "삭제된 프로젝트입니다."),
 
+    // APPLY
+    NOT_FOUND_APPLY("APL1", 404, "지원서를 찾을 수 없습니다."),
+
     // FILE
     NOT_FOUND_FILE("FILE1", 404, "파일을 찾을 수 없습니다."),
     FILE_SIZE_EXCEED("FILE2", 400, "파일 사이즈를 초과하였습니다."),
@@ -46,6 +49,7 @@ public enum ErrorCode {
     REQUEST_VALUE_INVALID("CMM5", 400, "입력값이 올바르지 않습니다."),
     REQUIRED_PARAMETER_MISSING("CMM6", 400, "필수 파라미터가 존재하지 않습니다."),
     HTTP_MESSAGE_NOT_READABLE("CMM7", 400, "요청 메시지를 읽을 수 없습니다. 요청 형식을 확인해 주세요."),
+    ACCESS_DENIED("CMM8", 403, "해당 요청에 대한 접근 권한이 없습니다."),
 
     // DOMAIN
     SKILL_NOT_VALID("DMN1", 400, "기술스택에 유효하지 않은 값이 존재합니다."),

--- a/src/main/java/com/whatpl/global/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/whatpl/global/exception/ExceptionControllerAdvice.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -103,6 +104,12 @@ public class ExceptionControllerAdvice {
                 .message(String.format("%s {%s}", requiredParameterMissing.getMessage(), e.getRequestPartName()))
                 .status(requiredParameterMissing.getStatus())
                 .build();
+        return new ResponseEntity<>(errorResponse, errorResponse.getStatus());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.ACCESS_DENIED);
         return new ResponseEntity<>(errorResponse, errorResponse.getStatus());
     }
 }

--- a/src/main/java/com/whatpl/global/listener/InitDataLoader.java
+++ b/src/main/java/com/whatpl/global/listener/InitDataLoader.java
@@ -37,6 +37,7 @@ public class InitDataLoader implements ApplicationListener<ApplicationReadyEvent
     private void setupInitMembers() {
         createMemberIfNotFound(Set.of(Skill.JAVA, Skill.SQL));
         createMemberIfNotFound(Set.of(Skill.FIGMA, Skill.KOTLIN));
+        createMemberIfNotFound(Set.of(Skill.PYTHON, Skill.TYPE_SCRIPT));
     }
 
     /**

--- a/src/main/java/com/whatpl/global/security/permission/WhatplPermissionEvaluator.java
+++ b/src/main/java/com/whatpl/global/security/permission/WhatplPermissionEvaluator.java
@@ -1,0 +1,45 @@
+package com.whatpl.global.security.permission;
+
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.global.security.permission.manager.WhatplPermissionManager;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * 글로벌 Authorization 평가 클래스입니다.
+ * 해당 클래스는 메소드 시큐리티로써 AOP 방식으로 동작합니다.
+ * permissionManagers는 com.whatpl.global.config.MethodSecurityConfig에서 등록합니다.
+ * targetType(평가자원) 별로 권한평가를 처리할 WhatplPermissionManager를 정의해야 합니다.
+ * WhatplPermissionManager의 구현체에서 실제 targetType(평가자원)에 대한 권한처리를 수행합니다.
+ *
+ * AOP 적용이 필요한 메서드에 @PreAuthorize 애노테이션(해당 애노테이션이 적용된 메서드가 포인트컷입니다.)을 적용하고, SpEL로 hasPermission메서드를 호출합니다.
+ * ex) @PreAuthorize("hasPermission(#applyId, 'APPLY', 'READ')")
+ */
+public class WhatplPermissionEvaluator implements PermissionEvaluator {
+
+    private final Map<String, WhatplPermissionManager> permissionManagers;
+
+    public WhatplPermissionEvaluator(Map<String, WhatplPermissionManager> permissionManagers) {
+        this.permissionManagers = permissionManagers;
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+        // 필요시 구현
+        return false;
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+        if (authentication == null || targetType == null || !(permission instanceof String)) {
+            return false;
+        }
+        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+        WhatplPermissionManager whatplPermissionManager = permissionManagers.get(targetType.toUpperCase());
+
+        return whatplPermissionManager.hasPrivilege(principal, (Long) targetId, permission.toString().toUpperCase());
+    }
+}

--- a/src/main/java/com/whatpl/global/security/permission/manager/ApplyPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/ApplyPermissionManager.java
@@ -1,0 +1,40 @@
+package com.whatpl.global.security.permission.manager;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.repository.ApplyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ApplyPermissionManager implements WhatplPermissionManager {
+
+    private final ApplyRepository applyRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission) {
+        if (permission.equals("READ")) {
+            return hasReadPrivilege(memberPrincipal, targetId);
+        }
+        return false;
+    }
+
+    /**
+     * 프로젝트 지원서 읽기 권한
+     * 지원자 or 프로젝트 등록자
+     */
+    private boolean hasReadPrivilege(MemberPrincipal memberPrincipal, Long applyId) {
+        Apply apply = applyRepository.findByIdWithProjectAndApplicant(applyId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_APPLY));
+
+        boolean isApplicant = apply.getApplicant().getId().equals(memberPrincipal.getId());
+        boolean isProjectWriter = apply.getProject().getWriter().getId().equals(memberPrincipal.getId());
+
+        return isApplicant || isProjectWriter;
+    }
+}

--- a/src/main/java/com/whatpl/global/security/permission/manager/WhatplPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/WhatplPermissionManager.java
@@ -1,0 +1,8 @@
+package com.whatpl.global.security.permission.manager;
+
+import com.whatpl.global.security.domain.MemberPrincipal;
+
+public interface WhatplPermissionManager {
+
+    boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission);
+}

--- a/src/main/java/com/whatpl/project/controller/ProjectController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package com.whatpl.project.controller;
 
 import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.dto.ProjectApplyReadResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
 import com.whatpl.project.dto.ProjectCreateRequest;
 import com.whatpl.project.service.ProjectApplyService;
@@ -8,11 +9,9 @@ import com.whatpl.project.service.ProjectWriteService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -42,5 +41,15 @@ public class ProjectController {
         String createdResourceUri = String.format("/projects/%d/applications/%d", projectId, applyId);
 
         return ResponseEntity.created(URI.create(createdResourceUri)).build();
+    }
+
+    @PreAuthorize("hasPermission(#applyId, 'APPLY', 'READ')")
+    @GetMapping("/projects/{projectId}/applications/{applyId}")
+    public ResponseEntity<ProjectApplyReadResponse> applyRead(@PathVariable Long projectId,
+                                          @PathVariable Long applyId) {
+
+        ProjectApplyReadResponse applyReadResponse = projectApplyService.read(projectId, applyId);
+
+        return ResponseEntity.ok(applyReadResponse);
     }
 }

--- a/src/main/java/com/whatpl/project/controller/ProjectController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectController.java
@@ -33,13 +33,13 @@ public class ProjectController {
         return ResponseEntity.created(URI.create(createdResourceUri)).build();
     }
 
-    @PostMapping("/projects/{projectId}/apply")
+    @PostMapping("/projects/{projectId}/applications")
     public ResponseEntity<Void> apply(@PathVariable Long projectId,
                                       @Valid @RequestBody ProjectApplyRequest request,
                                       @AuthenticationPrincipal MemberPrincipal principal) {
 
         Long applyId = projectApplyService.apply(request, projectId, principal.getId());
-        String createdResourceUri = String.format("/projects/%d/apply", applyId);
+        String createdResourceUri = String.format("/projects/%d/applications/%d", projectId, applyId);
 
         return ResponseEntity.created(URI.create(createdResourceUri)).build();
     }

--- a/src/main/java/com/whatpl/project/controller/ProjectController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectController.java
@@ -1,8 +1,12 @@
 package com.whatpl.project.controller;
 
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.domain.enums.ApplyStatus;
 import com.whatpl.project.dto.ProjectApplyReadResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
+import com.whatpl.project.dto.ProjectApplyStatusRequest;
 import com.whatpl.project.dto.ProjectCreateRequest;
 import com.whatpl.project.service.ProjectApplyService;
 import com.whatpl.project.service.ProjectWriteService;
@@ -46,10 +50,24 @@ public class ProjectController {
     @PreAuthorize("hasPermission(#applyId, 'APPLY', 'READ')")
     @GetMapping("/projects/{projectId}/applications/{applyId}")
     public ResponseEntity<ProjectApplyReadResponse> applyRead(@PathVariable Long projectId,
-                                          @PathVariable Long applyId) {
+                                                              @PathVariable Long applyId) {
 
         ProjectApplyReadResponse applyReadResponse = projectApplyService.read(projectId, applyId);
 
         return ResponseEntity.ok(applyReadResponse);
+    }
+
+    @PreAuthorize("hasPermission(#applyId, 'APPLY', 'STATUS')")
+    @PatchMapping("/projects/{projectId}/applications/{applyId}/status")
+    public ResponseEntity<ProjectApplyReadResponse> applyStatus(@PathVariable Long projectId,
+                                                                @PathVariable Long applyId,
+                                                                @Valid @RequestBody ProjectApplyStatusRequest request) {
+
+        if (ApplyStatus.WAITING.equals(request.getApplyStatus())) {
+            throw new BizException(ErrorCode.CANT_PROCESS_WAITING);
+        }
+        projectApplyService.status(projectId, applyId, request.getApplyStatus());
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whatpl/project/controller/ProjectController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectController.java
@@ -1,12 +1,15 @@
 package com.whatpl.project.controller;
 
 import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.dto.ProjectApplyRequest;
 import com.whatpl.project.dto.ProjectCreateRequest;
+import com.whatpl.project.service.ProjectApplyService;
 import com.whatpl.project.service.ProjectWriteService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +21,7 @@ import java.net.URI;
 public class ProjectController {
 
     private final ProjectWriteService projectWriteService;
+    private final ProjectApplyService projectApplyService;
 
     @PostMapping("/projects")
     public ResponseEntity<Void> write(@Valid @RequestBody ProjectCreateRequest request,
@@ -25,6 +29,17 @@ public class ProjectController {
 
         Long projectId = projectWriteService.createProject(request, principal.getId());
         String createdResourceUri = String.format("/projects/%d", projectId);
+
+        return ResponseEntity.created(URI.create(createdResourceUri)).build();
+    }
+
+    @PostMapping("/projects/{projectId}/apply")
+    public ResponseEntity<Void> apply(@PathVariable Long projectId,
+                                      @Valid @RequestBody ProjectApplyRequest request,
+                                      @AuthenticationPrincipal MemberPrincipal principal) {
+
+        Long applyId = projectApplyService.apply(request, projectId, principal.getId());
+        String createdResourceUri = String.format("/projects/%d/apply", applyId);
 
         return ResponseEntity.created(URI.create(createdResourceUri)).build();
     }

--- a/src/main/java/com/whatpl/project/converter/ApplyModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ApplyModelConverter.java
@@ -1,0 +1,22 @@
+package com.whatpl.project.converter;
+
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.dto.ProjectApplyReadResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ApplyModelConverter {
+
+    public static ProjectApplyReadResponse convert(Apply apply) {
+        return ProjectApplyReadResponse.builder()
+                .projectId(apply.getProject().getId())
+                .applyId(apply.getId())
+                .applicantId(apply.getApplicant().getId())
+                .applicantNickname(apply.getApplicant().getNickname())
+                .status(apply.getStatus())
+                .job(apply.getJob())
+                .content(apply.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/whatpl/project/converter/ApplyModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ApplyModelConverter.java
@@ -17,6 +17,7 @@ public final class ApplyModelConverter {
                 .status(apply.getStatus())
                 .job(apply.getJob())
                 .content(apply.getContent())
+                .recruiterReadAt(apply.getRecruiterReadAt())
                 .build();
     }
 }

--- a/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
@@ -7,14 +7,14 @@ import com.whatpl.project.domain.ProjectSkill;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.domain.RecruitJob;
 import com.whatpl.project.dto.ProjectCreateRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.Collections;
 import java.util.Optional;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ProjectModelConverter {
-
-    private ProjectModelConverter() {
-    }
 
     public static Project convert(final ProjectCreateRequest request, final Member writer, final Attachment representImage) {
         if(request == null || writer == null || representImage == null) {

--- a/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
@@ -45,8 +45,8 @@ public final class ProjectModelConverter {
                 .orElseGet(Collections::emptySet).stream()
                 .map(recruitJobField -> RecruitJob.builder()
                         .job(recruitJobField.getJob())
-                        .totalCount(recruitJobField.getTotalCount())
-                        .currentCount(0)
+                        .totalAmount(recruitJobField.getTotalCount())
+                        .currentAmount(0)
                         .build())
                 .forEach(project::addRecruitJob);
 

--- a/src/main/java/com/whatpl/project/domain/Apply.java
+++ b/src/main/java/com/whatpl/project/domain/Apply.java
@@ -1,0 +1,56 @@
+package com.whatpl.project.domain;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.member.domain.Member;
+import com.whatpl.project.domain.enums.ApplyStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "apply")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Apply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Job job;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private ApplyStatus status;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id")
+    private Member applicant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @Builder
+    public Apply(Job job, String content, ApplyStatus status, Member applicant, Project project) {
+        this.job = job;
+        this.content = content;
+        this.status = status;
+        this.applicant = applicant;
+        this.project = project;
+    }
+
+    public static Apply of(Job job, String content, Member applicant, Project project) {
+        return Apply.builder()
+                .job(job)
+                .content(content)
+                .status(ApplyStatus.WAITING)
+                .applicant(applicant)
+                .project(project)
+                .build();
+    }
+}

--- a/src/main/java/com/whatpl/project/domain/Apply.java
+++ b/src/main/java/com/whatpl/project/domain/Apply.java
@@ -1,19 +1,21 @@
 package com.whatpl.project.domain;
 
+import com.whatpl.global.common.BaseTimeEntity;
 import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.member.domain.Member;
 import com.whatpl.project.domain.enums.ApplyStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @Table(name = "apply")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Apply {
+public class Apply extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,6 +28,9 @@ public class Apply {
 
     @Enumerated(EnumType.STRING)
     private ApplyStatus status;
+
+    @Setter
+    private LocalDateTime recruiterReadAt;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id")
@@ -52,5 +57,14 @@ public class Apply {
                 .applicant(applicant)
                 .project(project)
                 .build();
+    }
+
+    //==비즈니스 로직==//
+    public void changeStatus(ApplyStatus status) {
+        if (!ApplyStatus.WAITING.equals(getStatus())) {
+            // 이미 처리된 지원서는 수정 불가
+            throw new BizException(ErrorCode.ALREADY_PROCESSED_APPLY);
+        }
+        this.status = status;
     }
 }

--- a/src/main/java/com/whatpl/project/domain/Project.java
+++ b/src/main/java/com/whatpl/project/domain/Project.java
@@ -2,9 +2,9 @@ package com.whatpl.project.domain;
 
 import com.whatpl.attachment.domain.Attachment;
 import com.whatpl.global.common.domain.enums.Career;
-import com.whatpl.member.domain.Member;
 import com.whatpl.global.common.domain.enums.Subject;
 import com.whatpl.global.common.domain.enums.WorkTime;
+import com.whatpl.member.domain.Member;
 import com.whatpl.project.domain.enums.MeetingType;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.domain.enums.UpDown;

--- a/src/main/java/com/whatpl/project/domain/Project.java
+++ b/src/main/java/com/whatpl/project/domain/Project.java
@@ -9,10 +9,7 @@ import com.whatpl.project.domain.enums.MeetingType;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.domain.enums.UpDown;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -36,6 +33,7 @@ public class Project {
 
     private LocalDate endDate;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private ProjectStatus status;
 

--- a/src/main/java/com/whatpl/project/domain/RecruitJob.java
+++ b/src/main/java/com/whatpl/project/domain/RecruitJob.java
@@ -4,6 +4,8 @@ import com.whatpl.global.common.domain.enums.Job;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.Objects;
+
 @Getter
 @Entity
 @Table(name = "recruit_job")
@@ -14,11 +16,12 @@ public class RecruitJob {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     private Job job;
 
-    private Integer totalCount;
+    private Integer totalAmount;
 
-    private Integer currentCount;
+    private Integer currentAmount;
 
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
@@ -26,9 +29,14 @@ public class RecruitJob {
     private Project project;
 
     @Builder
-    public RecruitJob(Job job, Integer totalCount, Integer currentCount) {
+    public RecruitJob(Job job, Integer totalAmount, Integer currentAmount) {
         this.job = job;
-        this.totalCount = totalCount;
-        this.currentCount = currentCount;
+        this.totalAmount = totalAmount;
+        this.currentAmount = currentAmount;
+    }
+
+    //==비즈니스 로직==//
+    public boolean isFullJob() {
+        return Objects.equals(totalAmount, currentAmount);
     }
 }

--- a/src/main/java/com/whatpl/project/domain/RecruitJob.java
+++ b/src/main/java/com/whatpl/project/domain/RecruitJob.java
@@ -1,6 +1,8 @@
 package com.whatpl.project.domain;
 
 import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -38,5 +40,13 @@ public class RecruitJob {
     //==비즈니스 로직==//
     public boolean isFullJob() {
         return Objects.equals(totalAmount, currentAmount);
+    }
+
+    public void increaseCurrentAmount() {
+        // 모집인원이 초과될 경우 Error
+        if (isFullJob()) {
+            throw new BizException(ErrorCode.RECRUIT_COMPLETED_APPLY_JOB);
+        }
+        this.currentAmount++;
     }
 }

--- a/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
+++ b/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
@@ -15,8 +15,7 @@ public enum ApplyStatus {
 
     WAITING("승인 대기"),
     ACCEPTED("승인 완료"),
-    REJECTED("승인 거절"),
-    DELETED("삭제");
+    REJECTED("승인 거절");
 
     @JsonValue
     private final String value;

--- a/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
+++ b/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
@@ -1,8 +1,31 @@
 package com.whatpl.project.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
 public enum ApplyStatus {
-    WAITING,
-    ACCEPTED,
-    REJECTED,
-    DELETED
+
+    WAITING("승인 대기"),
+    ACCEPTED("승인 완료"),
+    REJECTED("승인 거절"),
+    DELETED("삭제");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static ApplyStatus from(String value) {
+        return Arrays.stream(ApplyStatus.values())
+                .filter(applyStatus -> applyStatus.getValue().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.APPLY_STATUS_NOT_VALID));
+    }
 }

--- a/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
+++ b/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
@@ -1,0 +1,8 @@
+package com.whatpl.project.domain.enums;
+
+public enum ApplyStatus {
+    WAITING,
+    ACCEPTED,
+    REJECTED,
+    DELETED
+}

--- a/src/main/java/com/whatpl/project/dto/ProjectApplyReadResponse.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectApplyReadResponse.java
@@ -2,10 +2,15 @@ package com.whatpl.project.dto;
 
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.project.domain.enums.ApplyStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
+@Builder
+@AllArgsConstructor
 public class ProjectApplyReadResponse {
 
     private final long projectId;
@@ -15,15 +20,5 @@ public class ProjectApplyReadResponse {
     private final Job job;
     private final ApplyStatus status;
     private final String content;
-
-    @Builder
-    public ProjectApplyReadResponse(long projectId, long applyId, long applicantId, String applicantNickname, Job job, ApplyStatus status, String content) {
-        this.projectId = projectId;
-        this.applyId = applyId;
-        this.applicantId = applicantId;
-        this.applicantNickname = applicantNickname;
-        this.job = job;
-        this.status = status;
-        this.content = content;
-    }
+    private final LocalDateTime recruiterReadAt;
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectApplyReadResponse.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectApplyReadResponse.java
@@ -1,0 +1,29 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.project.domain.enums.ApplyStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProjectApplyReadResponse {
+
+    private final long projectId;
+    private final long applyId;
+    private final long applicantId;
+    private final String applicantNickname;
+    private final Job job;
+    private final ApplyStatus status;
+    private final String content;
+
+    @Builder
+    public ProjectApplyReadResponse(long projectId, long applyId, long applicantId, String applicantNickname, Job job, ApplyStatus status, String content) {
+        this.projectId = projectId;
+        this.applyId = applyId;
+        this.applicantId = applicantId;
+        this.applicantNickname = applicantNickname;
+        this.job = job;
+        this.status = status;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/whatpl/project/dto/ProjectApplyRequest.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectApplyRequest.java
@@ -1,0 +1,20 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Job;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProjectApplyRequest {
+
+    @NotNull(message = "지원 직무는 필수 입력 항목입니다.")
+    private Job applyJob;
+
+    @NotBlank(message = "지원 글은 필수 입력 항목입니다.")
+    private String content;
+}

--- a/src/main/java/com/whatpl/project/dto/ProjectApplyStatusRequest.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectApplyStatusRequest.java
@@ -1,0 +1,18 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.project.domain.enums.ApplyStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectApplyStatusRequest {
+
+    @NotNull(message = "지원서 상태는 필수값입니다.")
+    private ApplyStatus applyStatus;
+}

--- a/src/main/java/com/whatpl/project/repository/ApplyRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ApplyRepository.java
@@ -1,0 +1,13 @@
+package com.whatpl.project.repository;
+
+import com.whatpl.member.domain.Member;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplyRepository extends JpaRepository<Apply, Long> {
+
+    Optional<Apply> findByProjectAndApplicant(Project project, Member applicant);
+}

--- a/src/main/java/com/whatpl/project/repository/ApplyRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ApplyRepository.java
@@ -4,10 +4,14 @@ import com.whatpl.member.domain.Member;
 import com.whatpl.project.domain.Apply;
 import com.whatpl.project.domain.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     Optional<Apply> findByProjectAndApplicant(Project project, Member applicant);
+
+    @Query("select a from Apply a left join fetch a.project left join fetch a.applicant where a.id = :id")
+    Optional<Apply> findByIdWithProjectAndApplicant(Long id);
 }

--- a/src/main/java/com/whatpl/project/repository/ProjectRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectRepository.java
@@ -2,6 +2,12 @@ package com.whatpl.project.repository;
 
 import com.whatpl.project.domain.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Query("select p from Project p left join fetch p.recruitJobs where p.id = :id")
+    Optional<Project> findByIdWithRecruitJobs(Long id);
 }

--- a/src/main/java/com/whatpl/project/service/ProjectApplyService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectApplyService.java
@@ -1,0 +1,86 @@
+package com.whatpl.project.service;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.RecruitJob;
+import com.whatpl.project.domain.enums.ProjectStatus;
+import com.whatpl.project.dto.ProjectApplyRequest;
+import com.whatpl.project.repository.ApplyRepository;
+import com.whatpl.project.repository.ProjectRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectApplyService {
+
+    private final MemberRepository memberRepository;
+    private final ProjectRepository projectRepository;
+    private final ApplyRepository applyRepository;
+
+    @Transactional
+    public Long apply(final ProjectApplyRequest request, final long projectId, final long applicantId) {
+        Project project = projectRepository.findByIdWithRecruitJobs(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        Member applicant = memberRepository.findById(applicantId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+
+        // 삭제된 프로젝트는 지원 불가
+        validateDeletedProject(project);
+        // 모집완료된 프로젝트는 지원 불가
+        validateCompletedRecruitment(project);
+        // 프로젝트 등록자는 본인이 등록한 프로젝트에 지원 불가
+        validateWriter(project, applicant);
+        // 모집직군에 지원하는 직무가 없을 경우, 모집직군에 지원하는 직무가 마감된 경우 지원 불가
+        validateFullJob(project, request.getApplyJob());
+        // 이미 지원한 프로젝트는 지원 불가
+        validateDuplicatedApply(project, applicant);
+
+        Apply apply = Apply.of(request.getApplyJob(), request.getContent(), applicant, project);
+        Apply savedApply = applyRepository.save(apply);
+        return savedApply.getId();
+    }
+
+    private void validateDeletedProject(Project project) {
+        if (project.getStatus().equals(ProjectStatus.DELETED)) {
+            throw new BizException(ErrorCode.DELETED_PROJECT);
+        }
+    }
+
+    private void validateCompletedRecruitment(Project project) {
+        if (project.getStatus().equals(ProjectStatus.COMPLETED)) {
+            throw new BizException(ErrorCode.COMPLETED_RECRUITMENT);
+        }
+    }
+
+    private void validateWriter(Project project, Member applicant) {
+        if (project.getWriter().equals(applicant)) {
+            throw new BizException(ErrorCode.WRITER_NOT_APPLY);
+        }
+    }
+
+    private void validateFullJob(Project project, Job applyJob) {
+        RecruitJob matchedRecruitJob = project.getRecruitJobs().stream()
+                .filter(recruitJob -> recruitJob.getJob().equals(applyJob))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_MATCH_APPLY_JOB_WITH_PROJECT));
+        if (matchedRecruitJob.isFullJob()) {
+            throw new BizException(ErrorCode.RECRUIT_COMPLETED_APPLY_JOB);
+        }
+    }
+
+    private void validateDuplicatedApply(Project project, Member applicant) {
+        boolean isDuplicated = applyRepository.findByProjectAndApplicant(project, applicant)
+                .isPresent();
+
+        if (isDuplicated) {
+            throw new BizException(ErrorCode.DUPLICATED_APPLY);
+        }
+    }
+}

--- a/src/main/java/com/whatpl/project/service/ProjectApplyService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectApplyService.java
@@ -3,20 +3,25 @@ package com.whatpl.project.service;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.repository.MemberRepository;
 import com.whatpl.project.converter.ApplyModelConverter;
 import com.whatpl.project.domain.Apply;
 import com.whatpl.project.domain.Project;
 import com.whatpl.project.domain.RecruitJob;
+import com.whatpl.project.domain.enums.ApplyStatus;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.dto.ProjectApplyReadResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
 import com.whatpl.project.repository.ApplyRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +54,7 @@ public class ProjectApplyService {
         return savedApply.getId();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ProjectApplyReadResponse read(final long projectId, final long applyId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
@@ -60,7 +65,37 @@ public class ProjectApplyService {
             throw new BizException(ErrorCode.NOT_MATCH_PROJECT_APPLY);
         }
 
+        // 모집자가 지원서를 읽을 경우 조회한 시간 update
+        MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (principal.getId() == project.getWriter().getId() && apply.getRecruiterReadAt() == null) {
+            apply.setRecruiterReadAt(LocalDateTime.now());
+        }
+
         return ApplyModelConverter.convert(apply);
+    }
+
+    @Transactional
+    public void status(final long projectId, final long applyId, final ApplyStatus applyStatus) {
+        Project project = projectRepository.findByIdWithRecruitJobs(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        Apply apply = applyRepository.findByIdWithProjectAndApplicant(applyId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_APPLY));
+
+        if (!project.getId().equals(apply.getProject().getId())) {
+            throw new BizException(ErrorCode.NOT_MATCH_PROJECT_APPLY);
+        }
+
+        RecruitJob recruitJob = project.getRecruitJobs().stream()
+                .filter(rj -> rj.getJob().equals(apply.getJob()))
+                .findFirst()
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_MATCH_APPLY_JOB_WITH_PROJECT));
+
+        // 지원서의 상태를 승인/거절 상태로 변경한다. 만약, 이미 처리된 지원서라면 BizException 발생
+        apply.changeStatus(applyStatus);
+        if (applyStatus.equals(ApplyStatus.ACCEPTED)) {
+            // 지원서 승인일 경우 프로젝트 모집직군의 현재 인원을 증가한다. 만약, 모집인원이 초과될 경우 BizException 발생
+            recruitJob.increaseCurrentAmount();
+        }
     }
 
     private void validateDeletedProject(Project project) {

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -7,6 +7,7 @@ import com.whatpl.global.jwt.JwtProperties;
 import com.whatpl.global.jwt.JwtService;
 import com.whatpl.member.service.MemberLoginService;
 import com.whatpl.member.service.MemberProfileService;
+import com.whatpl.project.service.ProjectApplyService;
 import com.whatpl.project.service.ProjectWriteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,9 @@ public abstract class BaseSecurityWebMvcTest {
 
     @MockBean
     protected ProjectWriteService projectWriteService;
+
+    @MockBean
+    protected ProjectApplyService projectApplyService;
 
     @BeforeEach
     protected void init() {

--- a/src/test/java/com/whatpl/global/common/domain/GlobalDomainControllerTest.java
+++ b/src/test/java/com/whatpl/global/common/domain/GlobalDomainControllerTest.java
@@ -44,7 +44,8 @@ class GlobalDomainControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("careers").type(JsonFieldType.ARRAY).description("경력"),
                                 fieldWithPath("skills").type(JsonFieldType.ARRAY).description("기술 스택"),
                                 fieldWithPath("subjects").type(JsonFieldType.ARRAY).description("관심주제(도메인)"),
-                                fieldWithPath("workTimes").type(JsonFieldType.ARRAY).description("작업 가능 시간")
+                                fieldWithPath("workTimes").type(JsonFieldType.ARRAY).description("작업 가능 시간"),
+                                fieldWithPath("applyStatuses").type(JsonFieldType.ARRAY).description("프로젝트 지원 상태")
                         )
                 ));
     }

--- a/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
@@ -7,6 +7,7 @@ import com.whatpl.global.security.model.WithMockWhatplMember;
 import com.whatpl.project.domain.enums.ApplyStatus;
 import com.whatpl.project.dto.ProjectApplyReadResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
+import com.whatpl.project.dto.ProjectApplyStatusRequest;
 import com.whatpl.project.dto.ProjectCreateRequest;
 import com.whatpl.project.model.ProjectCreateRequestFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -18,14 +19,14 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDateTime;
+
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -113,7 +114,20 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .andDo(print())
                 .andDo(document("create-project-apply",
                         resourceDetails().tag(ApiDocTag.PROJECT.getTag())
-                                .summary("프로젝트 지원"),
+                                .summary("프로젝트 지원")
+                                .description("""
+                                        프로젝트에 지원합니다.
+                                        
+                                        삭제된 프로젝트는 지원 불가
+                                        
+                                        모집완료된 프로젝트는 지원 불가
+                                        
+                                        프로젝트 등록자는 본인이 등록한 프로젝트에 지원 불가
+                                        
+                                        모집직군에 지원하는 직무가 없을 경우, 모집직군에 지원하는 직무가 마감된 경우 지원 불가
+                                        
+                                        이미 지원한 프로젝트는 지원 불가
+                                        """),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
                         ),
@@ -134,6 +148,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
         // given
         long projectId = 1L;
         long applyId = 1L;
+        LocalDateTime recruiterReadAt = LocalDateTime.now();
         ProjectApplyReadResponse response = ProjectApplyReadResponse.builder()
                 .projectId(projectId)
                 .applyId(applyId)
@@ -142,6 +157,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .status(ApplyStatus.WAITING)
                 .job(Job.BACKEND_DEVELOPER)
                 .content("지원서 내용")
+                .recruiterReadAt(recruiterReadAt)
                 .build();
         when(projectApplyService.read(projectId, applyId))
                 .thenReturn(response);
@@ -159,12 +175,18 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.applicantNickname").value(response.getApplicantNickname()),
                         jsonPath("$.job").value(response.getJob().getValue()),
                         jsonPath("$.status").value(response.getStatus().getValue()),
-                        jsonPath("$.content").value(response.getContent())
+                        jsonPath("$.content").value(response.getContent()),
+                        jsonPath("$.recruiterReadAt").value(recruiterReadAt.toString().substring(0, recruiterReadAt.toString().length() - 2))
                 )
                 .andDo(print())
                 .andDo(document("read-project-apply",
                         resourceDetails().tag(ApiDocTag.PROJECT.getTag())
-                                .summary("프로젝트 지원서 조회"),
+                                .summary("프로젝트 지원서 조회")
+                                .description("""
+                                        프로젝트 지원서를 조회합니다.
+                                        
+                                        프로젝트의 지원자, 모집자만 조회 가능합니다.
+                                        """),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
                         ),
@@ -179,7 +201,52 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("applicantNickname").type(JsonFieldType.STRING).description("지원자 닉네임"),
                                 fieldWithPath("job").type(JsonFieldType.STRING).description("지원 직무"),
                                 fieldWithPath("status").type(JsonFieldType.STRING).description("지원 상태"),
-                                fieldWithPath("content").type(JsonFieldType.STRING).description("지원 내용")
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("지원 내용"),
+                                fieldWithPath("recruiterReadAt").type(JsonFieldType.STRING).description("모집자 조회 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("프로젝트 지원서 승인/거절 API Docs")
+    void applyStatus() throws Exception {
+        // given
+        long projectId = 1L;
+        long applyId = 1L;
+        ProjectApplyStatusRequest request = new ProjectApplyStatusRequest(ApplyStatus.ACCEPTED);
+        String requestJson = objectMapper.writeValueAsString(request);
+        doNothing().when(projectApplyService).status(anyLong(), anyLong(), any(ApplyStatus.class));
+
+        // expected
+        mockMvc.perform(patch("/projects/{projectId}/applications/{applyId}/status", projectId, applyId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                .andExpectAll(
+                        status().isNoContent()
+                )
+                .andDo(print())
+                .andDo(document("update-project-apply-status",
+                        resourceDetails().tag(ApiDocTag.PROJECT.getTag())
+                                .summary("프로젝트 지원서 승인/거절")
+                                .description("""
+                                        프로젝트 지원서를 승인/거절합니다.
+                                        
+                                        프로젝트의 모집자만 승인/거절 가능합니다.
+                                        
+                                        승인 대기 상태로는 변경할 수 없습니다. (승인/거절만 가능)
+                                        """),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        pathParameters(
+                                parameterWithName("projectId").description("프로젝트 ID"),
+                                parameterWithName("applyId").description("지원서 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("applyStatus").type(JsonFieldType.STRING).description("지원 상태")
                         )
                 ));
     }

--- a/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
@@ -148,7 +149,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
         // given
         long projectId = 1L;
         long applyId = 1L;
-        LocalDateTime recruiterReadAt = LocalDateTime.now();
+        LocalDateTime recruiterReadAt = LocalDateTime.now(Clock.systemDefaultZone());
         ProjectApplyReadResponse response = ProjectApplyReadResponse.builder()
                 .projectId(projectId)
                 .applyId(applyId)
@@ -176,7 +177,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.job").value(response.getJob().getValue()),
                         jsonPath("$.status").value(response.getStatus().getValue()),
                         jsonPath("$.content").value(response.getContent()),
-                        jsonPath("$.recruiterReadAt").value(recruiterReadAt.toString().substring(0, recruiterReadAt.toString().length() - 2))
+                        jsonPath("$.recruiterReadAt").value(response.getRecruiterReadAt().toString())
                 )
                 .andDo(print())
                 .andDo(document("read-project-apply",

--- a/src/test/java/com/whatpl/project/model/ApplyFixture.java
+++ b/src/test/java/com/whatpl/project/model/ApplyFixture.java
@@ -1,0 +1,30 @@
+package com.whatpl.project.model;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.member.domain.Member;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.enums.ApplyStatus;
+
+public class ApplyFixture {
+
+    public static Apply waiting(Job job, Member applicant, Project project) {
+        return Apply.builder()
+                .job(job)
+                .content("test content")
+                .status(ApplyStatus.WAITING)
+                .applicant(applicant)
+                .project(project)
+                .build();
+    }
+
+    public static Apply accepted(Job job, Member applicant, Project project) {
+        return Apply.builder()
+                .job(job)
+                .content("test content")
+                .status(ApplyStatus.ACCEPTED)
+                .applicant(applicant)
+                .project(project)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/project/model/ProjectFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectFixture.java
@@ -4,6 +4,7 @@ import com.whatpl.global.common.domain.enums.Career;
 import com.whatpl.global.common.domain.enums.Subject;
 import com.whatpl.global.common.domain.enums.WorkTime;
 import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.RecruitJob;
 import com.whatpl.project.domain.enums.MeetingType;
 import com.whatpl.project.domain.enums.UpDown;
 
@@ -24,5 +25,15 @@ public class ProjectFixture {
                 .wishCareerUpDown(UpDown.UP)
                 .wishWorkTime(WorkTime.TEN_TO_TWENTY)
                 .build();
+    }
+
+    public static Project withRecruitJobs(RecruitJob... recruitJobs) {
+        Project project = create();
+        if(recruitJobs != null) {
+            for (RecruitJob recruitJob : recruitJobs) {
+                project.addRecruitJob(recruitJob);
+            }
+        }
+        return project;
     }
 }

--- a/src/test/java/com/whatpl/project/model/ProjectFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectFixture.java
@@ -1,0 +1,28 @@
+package com.whatpl.project.model;
+
+import com.whatpl.global.common.domain.enums.Career;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.global.common.domain.enums.WorkTime;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.enums.MeetingType;
+import com.whatpl.project.domain.enums.UpDown;
+
+import java.time.LocalDate;
+
+public class ProjectFixture {
+
+    public static Project create() {
+        return Project.builder()
+                .title("테스트 타이틀")
+                .subject(Subject.SOCIAL_MEDIA)
+                .content("<p>테스트 콘텐츠 HTML<p>")
+                .profitable(false)
+                .meetingType(MeetingType.ONLINE)
+                .startDate(LocalDate.of(2024, 4, 1))
+                .endDate(LocalDate.of(2024, 6, 30))
+                .wishCareer(Career.ONE)
+                .wishCareerUpDown(UpDown.UP)
+                .wishWorkTime(WorkTime.TEN_TO_TWENTY)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/project/model/RecruitJobFixture.java
+++ b/src/test/java/com/whatpl/project/model/RecruitJobFixture.java
@@ -1,0 +1,23 @@
+package com.whatpl.project.model;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.project.domain.RecruitJob;
+
+public class RecruitJobFixture {
+
+    public static RecruitJob notFull(Job job) {
+        return RecruitJob.builder()
+                .job(job)
+                .totalAmount(10)
+                .currentAmount(0)
+                .build();
+    }
+
+    public static RecruitJob full(Job job) {
+        return RecruitJob.builder()
+                .job(job)
+                .totalAmount(10)
+                .currentAmount(10)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/project/service/ProjectApplyServiceTest.java
+++ b/src/test/java/com/whatpl/project/service/ProjectApplyServiceTest.java
@@ -1,0 +1,170 @@
+package com.whatpl.project.service;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.model.MemberFixture;
+import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.RecruitJob;
+import com.whatpl.project.domain.enums.ApplyStatus;
+import com.whatpl.project.domain.enums.ProjectStatus;
+import com.whatpl.project.dto.ProjectApplyRequest;
+import com.whatpl.project.model.ProjectFixture;
+import com.whatpl.project.repository.ApplyRepository;
+import com.whatpl.project.repository.ProjectRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectApplyServiceTest {
+
+    @InjectMocks
+    private ProjectApplyService projectApplyService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private ApplyRepository applyRepository;
+
+    @Test
+    @DisplayName("삭제된 프로젝트에 지원하면 실패")
+    void apply_deleted_project() {
+        // given
+        Project project = ProjectFixture.create();
+        Member writer = MemberFixture.onlyRequired();
+        project.setStatus(ProjectStatus.DELETED);
+        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content");
+        when(projectRepository.findByIdWithRecruitJobs(anyLong()))
+                .thenReturn(Optional.of(project));
+        when(memberRepository.findById(anyLong()))
+                .thenReturn(Optional.of(writer));
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectApplyService.apply(request, 0L, 0L));
+        assertEquals(ErrorCode.DELETED_PROJECT, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모집완료된 프로젝트에 지원하면 실패")
+    void apply_completed_project() {
+        // given
+        Project project = ProjectFixture.create();
+        Member writer = MemberFixture.onlyRequired();
+        project.setStatus(ProjectStatus.COMPLETED);
+        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content");
+        when(projectRepository.findByIdWithRecruitJobs(anyLong()))
+                .thenReturn(Optional.of(project));
+        when(memberRepository.findById(anyLong()))
+                .thenReturn(Optional.of(writer));
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectApplyService.apply(request, 0L, 0L));
+        assertEquals(ErrorCode.COMPLETED_RECRUITMENT, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("본인이 등록한 프로젝트에 지원하면 실패")
+    void apply_writer_equals_applicant() {
+        Project project = ProjectFixture.create();
+        Member writer = MemberFixture.onlyRequired();
+        project.addRepresentImageAndWriter(null, writer);
+        project.setStatus(ProjectStatus.RECRUITING);
+        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content");
+        when(projectRepository.findByIdWithRecruitJobs(anyLong()))
+                .thenReturn(Optional.of(project));
+        when(memberRepository.findById(anyLong()))
+                .thenReturn(Optional.of(writer));
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectApplyService.apply(request, 0L, 0L));
+        assertEquals(ErrorCode.WRITER_NOT_APPLY, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모집직군에 지원하는 직무가 없으면 실패")
+    void apply_has_not_match_job_project() {
+        Project project = ProjectFixture.create();
+        Member writer = MemberFixture.onlyRequired();
+        project.addRepresentImageAndWriter(null, writer);
+        project.setStatus(ProjectStatus.RECRUITING);
+        project.addRecruitJob(new RecruitJob(Job.DESIGNER, 5, 0));
+
+        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content");
+        when(projectRepository.findByIdWithRecruitJobs(anyLong()))
+                .thenReturn(Optional.of(project));
+        when(memberRepository.findById(anyLong()))
+                .thenReturn(Optional.of(MemberFixture.withAll()));
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectApplyService.apply(request, 0L, 0L));
+        assertEquals(ErrorCode.NOT_MATCH_APPLY_JOB_WITH_PROJECT, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모집직군에 지원하는 직무가 마감된 경우 실패")
+    void apply_full_job_project() {
+        Project project = ProjectFixture.create();
+        Member writer = MemberFixture.onlyRequired();
+        project.addRepresentImageAndWriter(null, writer);
+        project.setStatus(ProjectStatus.RECRUITING);
+        project.addRecruitJob(new RecruitJob(Job.BACKEND_DEVELOPER, 5, 5));
+
+        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content");
+        when(projectRepository.findByIdWithRecruitJobs(anyLong()))
+                .thenReturn(Optional.of(project));
+        when(memberRepository.findById(anyLong()))
+                .thenReturn(Optional.of(MemberFixture.withAll()));
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectApplyService.apply(request, 0L, 0L));
+        assertEquals(ErrorCode.RECRUIT_COMPLETED_APPLY_JOB, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("이미 지원한 프로젝트에 지원하면 실패")
+    void apply_duplicated_apply_project() {
+        Project project = ProjectFixture.create();
+        Member writer = MemberFixture.onlyRequired();
+        project.addRepresentImageAndWriter(null, writer);
+        project.setStatus(ProjectStatus.RECRUITING);
+        project.addRecruitJob(new RecruitJob(Job.BACKEND_DEVELOPER, 5, 0));
+
+        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content");
+        when(projectRepository.findByIdWithRecruitJobs(anyLong()))
+                .thenReturn(Optional.of(project));
+        when(memberRepository.findById(anyLong()))
+                .thenReturn(Optional.of(MemberFixture.withAll()));
+        when(applyRepository.findByProjectAndApplicant(any(Project.class), any(Member.class)))
+                .thenReturn(Optional.of(new Apply(Job.BACKEND_DEVELOPER, "test content",
+                        ApplyStatus.WAITING, MemberFixture.withAll(), project)));
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectApplyService.apply(request, 0L, 0L));
+        assertEquals(ErrorCode.DUPLICATED_APPLY, bizException.getErrorCode());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #32 

## 📝작업 내용

- 로그인한 사용자는 등록된 프로젝트에 지원할 수 있습니다.
- 모집자는 지원서를 읽고 승인/거절할 수 있습니다.
- 지원서를 모집자가 읽었는지 확인할 수 있습니다.
- SpringSecurity의 PermissionEvaluator 를 구현했습니다.

## 💬리뷰 요구사항(선택)

- PermissionEvaluator 구현 부분을 공통화 했습니다.
- `WhatplPermissionEvaluator` 는 `Map<String, WhatplPermissionManager> permissionManagers` 필드를 가지는데, 해당 필드값은 `MethodSecurityConfig`에서 등록합니다.
- `WhatplPermissionManager` 는 자원과 행위에 대한 사용자의 권한(인가)을 확인하는 객체로, 권한확인이 필요한 자원이 있을 경우 구현해서 사용합니다.

- `WhatplPermissionEvaluator` - Manager에게 작업권한 위임 객체(메소드 시큐리티 AOP의 Advice입니다.)
![image](https://github.com/whatpl/whatpl-backend/assets/39439576/760d3c63-d5e1-41ac-a726-309b923c8eec)

- `MethodSecurityConfig` - `whatplPermissionEvaluatorMap` 등록 시 참고
![image](https://github.com/whatpl/whatpl-backend/assets/39439576/1a545ef6-1868-416e-8d2d-eb291c219502)

- `ApplyPermissionManager` - Apply(지원서) 관련 권한 확인 Manager
![image](https://github.com/whatpl/whatpl-backend/assets/39439576/d049f5c1-5cfe-4a7b-ae70-d94fdbaa1896)

- AOP 적용 사례 참고
![image](https://github.com/whatpl/whatpl-backend/assets/39439576/4018740b-44b4-4960-b060-8a21476ecb24)
