### PR TITLE
프로젝트 좋아요 기능

### DIFF
--- a/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
@@ -4,6 +4,7 @@ package com.whatpl.global.config;
 import com.whatpl.global.security.permission.WhatplPermissionEvaluator;
 import com.whatpl.global.security.permission.manager.ApplyPermissionManager;
 import com.whatpl.global.security.permission.manager.ProjectCommentPermissionManager;
+import com.whatpl.global.security.permission.manager.ProjectLikePermissionManager;
 import com.whatpl.global.security.permission.manager.WhatplPermissionManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,12 +23,14 @@ public class MethodSecurityConfig {
 
     private final ApplyPermissionManager applyPermissionManager;
     private final ProjectCommentPermissionManager projectCommentPermissionManager;
+    private final ProjectLikePermissionManager projectLikePermissionManager;
 
     @Bean
     public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
         Map<String, WhatplPermissionManager> whatplPermissionEvaluatorMap = new HashMap<>();
         whatplPermissionEvaluatorMap.put("APPLY", applyPermissionManager);
         whatplPermissionEvaluatorMap.put("PROJECT_COMMENT", projectCommentPermissionManager);
+        whatplPermissionEvaluatorMap.put("PROJECT_LIKE", projectLikePermissionManager);
 
         DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
         expressionHandler.setPermissionEvaluator(new WhatplPermissionEvaluator(whatplPermissionEvaluatorMap));

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     CANT_PROCESS_WAITING("PRJ10", 400, "프로젝트 지원서를 대기 상태로 변경할 수 없습니다."),
     NOT_FOUND_PARENT_PROJECT_COMMENT("PRJ11", 404, "상위 댓글을 찾을 수 없습니다."),
     NOT_FOUND_PROJECT_COMMENT("PRJ12", 404, "댓글을 찾을 수 없습니다."),
+    NOT_MATCH_PROJECT_LIKE("PRJ13", 400, "프로젝트 ID와 좋아요 ID가 일치하지 않습니다."),
 
     // APPLY
     NOT_FOUND_APPLY("APL1", 404, "지원서를 찾을 수 없습니다."),

--- a/src/main/java/com/whatpl/global/security/permission/manager/ProjectLikePermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/ProjectLikePermissionManager.java
@@ -1,0 +1,35 @@
+package com.whatpl.global.security.permission.manager;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.domain.ProjectLike;
+import com.whatpl.project.repository.ProjectLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectLikePermissionManager implements WhatplPermissionManager{
+
+    private final ProjectLikeRepository projectLikeRepository;
+
+    @Override
+    public boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission) {
+        if (permission.equals("DELETE")) {
+            return hasDeletePrivilege(memberPrincipal, targetId);
+        }
+        return false;
+    }
+
+    /**
+     * 프로젝트 좋아요 삭제 권한
+     * 좋아요 등록한 사용자
+     */
+    private boolean hasDeletePrivilege(MemberPrincipal memberPrincipal, Long likeId) {
+        ProjectLike projectLike = projectLikeRepository.findWithMemberById(likeId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_DATA));
+
+        return projectLike.getMember().getId().equals(memberPrincipal.getId());
+    }
+}

--- a/src/main/java/com/whatpl/project/controller/ProjectLikeController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectLikeController.java
@@ -1,0 +1,39 @@
+package com.whatpl.project.controller;
+
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.dto.ProjectLikeResponse;
+import com.whatpl.project.service.ProjectLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProjectLikeController {
+
+    private final ProjectLikeService projectLikeService;
+
+    @PutMapping("/projects/{projectId}/likes")
+    public ResponseEntity<?> putLike(@PathVariable long projectId,
+                                     @AuthenticationPrincipal MemberPrincipal principal) {
+        long likeId = projectLikeService.putLike(projectId, principal.getId());
+        return ResponseEntity.ok(ProjectLikeResponse.builder()
+                .likeId(likeId)
+                .projectId(projectId)
+                .memberId(principal.getId())
+                .build());
+    }
+
+    @PreAuthorize("hasPermission(#likeId, 'PROJECT_LIKE', 'DELETE')")
+    @DeleteMapping("/projects/{projectId}/likes/{likeId}")
+    public ResponseEntity<Void> deleteLike(@PathVariable long projectId,
+                                           @PathVariable long likeId) {
+        projectLikeService.deleteLike(projectId, likeId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/whatpl/project/domain/ProjectLike.java
+++ b/src/main/java/com/whatpl/project/domain/ProjectLike.java
@@ -1,0 +1,34 @@
+package com.whatpl.project.domain;
+
+import com.whatpl.global.common.BaseTimeEntity;
+import com.whatpl.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "project_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public ProjectLike(Project project, Member member) {
+        this.project = project;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/whatpl/project/dto/ProjectLikeResponse.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectLikeResponse.java
@@ -1,0 +1,15 @@
+package com.whatpl.project.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ProjectLikeResponse {
+
+    private final long likeId;
+    private final long projectId;
+    private final long memberId;
+}

--- a/src/main/java/com/whatpl/project/repository/ProjectLikeRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectLikeRepository.java
@@ -1,0 +1,15 @@
+package com.whatpl.project.repository;
+
+import com.whatpl.project.domain.ProjectLike;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> {
+
+    Optional<ProjectLike> findByProjectIdAndMemberId(Long projectId, Long memberId);
+
+    @EntityGraph(attributePaths = {"member"})
+    Optional<ProjectLike> findWithMemberById(Long memberId);
+}

--- a/src/main/java/com/whatpl/project/service/ProjectLikeService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectLikeService.java
@@ -1,0 +1,48 @@
+package com.whatpl.project.service;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.ProjectLike;
+import com.whatpl.project.repository.ProjectLikeRepository;
+import com.whatpl.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectLikeService {
+
+    private final ProjectRepository projectRepository;
+    private final MemberRepository memberRepository;
+    private final ProjectLikeRepository projectLikeRepository;
+
+    @Transactional
+    public long putLike(final long projectId, final long memberId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        ProjectLike projectLike = projectLikeRepository.findByProjectIdAndMemberId(projectId, memberId)
+                .orElseGet(() -> ProjectLike.builder().project(project).member(member).build());
+
+        return projectLikeRepository.save(projectLike).getId();
+    }
+
+    @Transactional
+    public void deleteLike(final long projectId, final long likeId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        ProjectLike projectLike = projectLikeRepository.findById(likeId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_DATA));
+        if (!Objects.equals(projectLike.getProject().getId(), project.getId())) {
+            throw new BizException(ErrorCode.NOT_MATCH_PROJECT_LIKE);
+        }
+        projectLikeRepository.delete(projectLike);
+    }
+}

--- a/src/test/java/com/whatpl/ApiDocTag.java
+++ b/src/test/java/com/whatpl/ApiDocTag.java
@@ -11,6 +11,7 @@ public enum ApiDocTag {
     MEMBER("Members"),
     PROJECT("Projects"),
     PROJECT_COMMENT("Project Comments"),
+    PROJECT_LIKE("Project Likes"),
     ATTACHMENT("Attachments"),
     DOMAIN("Domains");
 

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -8,10 +8,7 @@ import com.whatpl.global.jwt.JwtService;
 import com.whatpl.global.upload.S3Uploader;
 import com.whatpl.member.service.MemberLoginService;
 import com.whatpl.member.service.MemberProfileService;
-import com.whatpl.project.service.ProjectApplyService;
-import com.whatpl.project.service.ProjectCommentService;
-import com.whatpl.project.service.ProjectReadService;
-import com.whatpl.project.service.ProjectWriteService;
+import com.whatpl.project.service.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -66,6 +63,9 @@ public abstract class BaseSecurityWebMvcTest {
 
     @MockBean
     protected S3Uploader s3Uploader;
+
+    @MockBean
+    protected ProjectLikeService projectLikeService;
 
     @BeforeEach
     protected void init() {

--- a/src/test/java/com/whatpl/project/controller/ProjectCommentControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectCommentControllerTest.java
@@ -160,7 +160,9 @@ class ProjectCommentControllerTest extends BaseSecurityWebMvcTest {
                                 .description("""
                                         프로젝트 댓글을 수정합니다.
                                         
-                                        Authorization - 프로젝트 댓글 작성자
+                                        [권한]
+                                        
+                                        - 프로젝트 댓글 작성자
                                         """),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
@@ -195,7 +197,9 @@ class ProjectCommentControllerTest extends BaseSecurityWebMvcTest {
                                 .description("""
                                         프로젝트 댓글을 삭제합니다.
                                         
-                                        Authorization - 프로젝트 댓글 작성자
+                                        [권한]
+                                        
+                                        - 프로젝트 댓글 작성자
                                         """),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")

--- a/src/test/java/com/whatpl/project/controller/ProjectLikeControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectLikeControllerTest.java
@@ -1,0 +1,105 @@
+package com.whatpl.project.controller;
+
+import com.whatpl.ApiDocTag;
+import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.global.security.model.WithMockWhatplMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.data.util.CastUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+class ProjectLikeControllerTest extends BaseSecurityWebMvcTest {
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("프로젝트 좋아요 등록 API Docs")
+    void putLike() throws Exception {
+        // given
+        long projectId = 1L;
+        long likeId = 1L;
+        when(projectLikeService.putLike(anyLong(), anyLong()))
+                .thenReturn(likeId);
+        MemberPrincipal principal = CastUtils.cast(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        long memberId = principal.getId();
+
+        // expected
+        mockMvc.perform(put("/projects/{projectId}/likes", projectId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON_VALUE),
+                        jsonPath("$.likeId").value(likeId),
+                        jsonPath("$.projectId").value(projectId),
+                        jsonPath("$.memberId").value(memberId)
+                )
+                .andDo(print())
+                .andDo(document("put-project-like",
+                        resourceDetails().tag(ApiDocTag.PROJECT_LIKE.getTag())
+                                .summary("프로젝트 좋아요 등록")
+                                .description("""
+                                        프로젝트 좋아요를 등록합니다.
+                                                                                
+                                        PUT 메소드로 사용해 항상 동일한 결과를 보장합니다. (멱등성)
+                                        """),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        responseFields(
+                                fieldWithPath("likeId").type(JsonFieldType.NUMBER).description("등록된 좋아요 ID"),
+                                fieldWithPath("projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("등록자 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("프로젝트 좋아요 삭제 API Docs")
+    void deleteLike() throws Exception {
+        // given
+        doNothing().when(projectLikeService).deleteLike(anyLong(), anyLong());
+
+        // expected
+        mockMvc.perform(delete("/projects/{projectId}/likes/{likeId}", 1L, 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpectAll(
+                        status().isNoContent()
+                )
+                .andDo(print())
+                .andDo(document("delete-project-like",
+                        resourceDetails().tag(ApiDocTag.PROJECT_LIKE.getTag())
+                                .summary("프로젝트 좋아요 삭제")
+                                .description("""
+                                        프로젝트 좋아요를 삭제합니다.
+                                        
+                                        [권한]
+                                        
+                                        - 프로젝트 좋아요 등록자
+                                        """),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #35 

## 📝작업 내용

- 프로젝트 모집글에 좋아요를 등록하고 삭제하는 기능 구현
- 좋아요 API는 PUT 메소드를 사용하여 항상 같은 결과 보장 (멱등성)
  - 좋아요 API를 여러 번 호출해도 좋아요는 1개만 등록 됨
- 좋아요 삭제 API는 좋아요 등록자만 허용하도록 권한 체크