### PR TITLE
프로젝트 참여 제안

### DIFF
--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
     NOT_MATCH_PROJECT_LIKE("PRJ13", 400, "프로젝트 ID와 좋아요 ID가 일치하지 않습니다."),
 
     // APPLY
-    NOT_FOUND_APPLY("APL1", 404, "지원서를 찾을 수 없습니다."),
+    NOT_FOUND_APPLY("APL1", 404, "지원정보를 찾을 수 없습니다."),
 
     // FILE
     NOT_FOUND_FILE("FILE1", 404, "파일을 찾을 수 없습니다."),

--- a/src/main/java/com/whatpl/global/security/permission/manager/ApplyPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/ApplyPermissionManager.java
@@ -4,7 +4,9 @@ import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.Project;
 import com.whatpl.project.repository.ApplyRepository;
+import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,19 +15,41 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ApplyPermissionManager implements WhatplPermissionManager {
 
+    private final ProjectRepository projectRepository;
     private final ApplyRepository applyRepository;
 
     @Override
     @Transactional(readOnly = true)
     public boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission) {
         return switch (permission) {
+            case "APPLY" -> hasApplyPrivilege(memberPrincipal);
+            case "OFFER" -> hasOfferPrivilege(memberPrincipal, targetId);
             case "STATUS" -> hasStatusPrivilege(memberPrincipal, targetId);
             default -> false;
         };
     }
 
     /**
-     * 프로젝트 지원서 상태 변경 권한 (지원서 수락/거절 use-case)
+     * 프로젝트 지원 권한
+     * 인증된 사용자
+     */
+    private boolean hasApplyPrivilege(MemberPrincipal memberPrincipal) {
+        return memberPrincipal != null;
+    }
+
+    /**
+     * 프로젝트 참여 제안 권한
+     * 프로젝트 등록자
+     */
+    private boolean hasOfferPrivilege(MemberPrincipal memberPrincipal, Long projectId) {
+        Project project = projectRepository.findWithWriterById(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        long writerId = project.getWriter().getId();
+        return writerId == memberPrincipal.getId();
+    }
+
+    /**
+     * 프로젝트 지원 상태 변경 권한 (지원 수락/거절 use-case)
      * 프로젝트 등록자
      */
     private boolean hasStatusPrivilege(MemberPrincipal memberPrincipal, Long applyId) {

--- a/src/main/java/com/whatpl/global/security/permission/manager/ApplyPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/ApplyPermissionManager.java
@@ -5,6 +5,7 @@ import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.project.domain.Apply;
 import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.enums.ApplyType;
 import com.whatpl.project.repository.ApplyRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -50,12 +51,15 @@ public class ApplyPermissionManager implements WhatplPermissionManager {
 
     /**
      * 프로젝트 지원 상태 변경 권한 (지원 수락/거절 use-case)
-     * 프로젝트 등록자
+     * 지원일 경우 프로젝트 등록자
+     * 참여 제안일 경우 프로젝트 지원자
      */
     private boolean hasStatusPrivilege(MemberPrincipal memberPrincipal, Long applyId) {
         Apply apply = applyRepository.findWithProjectAndApplicantById(applyId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_APPLY));
 
-        return apply.getProject().getWriter().getId().equals(memberPrincipal.getId());
+        return ApplyType.APPLY.equals(apply.getType()) ?
+                apply.getProject().getWriter().getId().equals(memberPrincipal.getId()) :
+                apply.getApplicant().getId().equals(memberPrincipal.getId());
     }
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectApplyRequest.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectApplyRequest.java
@@ -21,4 +21,6 @@ public class ProjectApplyRequest {
 
     @NotNull(message = "지원 타입은 필수 입력 항목입니다.")
     private ApplyType applyType;
+
+    private Long applicantId;
 }

--- a/src/main/java/com/whatpl/project/repository/ProjectRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectRepository.java
@@ -1,6 +1,7 @@
 package com.whatpl.project.repository;
 
 import com.whatpl.project.domain.Project;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,4 +11,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
 
     @Query("select p from Project p left join fetch p.recruitJobs where p.id = :id")
     Optional<Project> findWithRecruitJobsById(Long id);
+
+    @EntityGraph(attributePaths = {"writer"})
+    Optional<Project> findWithWriterById(Long id);
 }

--- a/src/test/java/com/whatpl/project/controller/ProjectApplyControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectApplyControllerTest.java
@@ -187,13 +187,15 @@ class ProjectApplyControllerTest extends BaseSecurityWebMvcTest {
                 .andDo(print())
                 .andDo(document("update-project-apply-status",
                         resourceDetails().tag(ApiDocTag.PROJECT.getTag())
-                                .summary("프로젝트 지원서 승인/거절")
+                                .summary("프로젝트 지원 또는 참여 제안 승인/거절")
                                 .description("""
                                         프로젝트 지원서를 승인/거절합니다.
-                                                                                
-                                        프로젝트의 모집자만 승인/거절 가능합니다.
-                                                                                
+                                        
                                         승인 대기 상태로는 변경할 수 없습니다. (승인/거절만 가능)
+                                        
+                                        [권한]
+                                        - 지원일 경우 프로젝트 등록자
+                                        - 참여제안일 경우 프로젝트 지원자
                                         """),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")

--- a/src/test/java/com/whatpl/project/controller/ProjectApplyControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectApplyControllerTest.java
@@ -2,13 +2,12 @@ package com.whatpl.project.controller;
 
 import com.whatpl.ApiDocTag;
 import com.whatpl.BaseSecurityWebMvcTest;
-import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.security.model.WithMockWhatplMember;
 import com.whatpl.project.domain.enums.ApplyStatus;
-import com.whatpl.project.domain.enums.ApplyType;
 import com.whatpl.project.dto.ApplyResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
 import com.whatpl.project.dto.ProjectApplyStatusRequest;
+import com.whatpl.project.model.ProjectApplyRequestFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,9 +17,10 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.util.Map;
+
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -30,7 +30,6 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -46,7 +45,80 @@ class ProjectApplyControllerTest extends BaseSecurityWebMvcTest {
     @DisplayName("프로젝트 지원 API Docs")
     void apply() throws Exception {
         // given
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "<p>테스트 콘텐츠 HTML<p>", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
+        Map<String, Object> map = Map.of(
+                "applyJob", request.getApplyJob(),
+                "content", request.getContent(),
+                "applyType", request.getApplyType());
+        String requestJson = objectMapper.writeValueAsString(map);
+        long projectId = 1L;
+        long applyId = 1L;
+        long chatRoomId = 1L;
+        ApplyResponse applyResponse = ApplyResponse.builder()
+                .applyId(applyId)
+                .projectId(projectId)
+                .chatRoomId(chatRoomId)
+                .build();
+        when(projectApplyService.apply(any(ProjectApplyRequest.class), anyLong(), anyLong()))
+                .thenReturn(applyResponse);
+
+        // expected
+        mockMvc.perform(post("/projects/{projectId}/apply", projectId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestJson)
+                )
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.applyId").value(applyId),
+                        jsonPath("$.projectId").value(projectId),
+                        jsonPath("$.chatRoomId").value(chatRoomId)
+                )
+                .andDo(print())
+                .andDo(document("project-apply",
+                        resourceDetails().tag(ApiDocTag.PROJECT.getTag())
+                                .summary("프로젝트 지원 또는 참여 제안")
+                                .description("""
+                                        프로젝트에 지원 또는 참여 제안 API입니다.
+                                        
+                                        [API 요구사항]
+                                        - 지원일 경우 요청 body의 applyType 값을 "APPLY"로 요청합니다.
+                                        - 참여 제안일 경우 요청 body의 applyType 값을 "OFFER"로 요청합니다.
+                                        - 요청 body의 applicantId는 참여 제안 요청에서 사용됩니다. 지원 요청에서는 사용되지 않습니다.
+                                        
+                                        [유효성 검증]
+                                        - 삭제된 프로젝트는 지원(참여 제안) 불가
+                                        - 모집완료된 프로젝트는 지원(참여 제안) 불가
+                                        - 프로젝트 등록자는 본인이 등록한 프로젝트에 지원(참여 제안) 불가
+                                        - 모집직군에 지원(참여 제안)하는 직무가 없을 경우, 모집직군에 지원하는 직무가 마감된 경우 지원(참여 제안) 불가
+                                        - 이미 지원(참여 제안)한 프로젝트는 지원(참여 제안) 불가
+                                        
+                                        [권한]
+                                        - 지원 - 인증된 모든 사용자
+                                        - 참여 제안 - 프로젝트 등록자
+                                        """),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        requestFields(
+                                fieldWithPath("applyJob").type(JsonFieldType.STRING).description("지원 직무"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("지원 글"),
+                                fieldWithPath("applyType").type(JsonFieldType.STRING).description("지원 타입")
+                        ),
+                        responseFields(
+                                fieldWithPath("applyId").type(JsonFieldType.NUMBER).description("지원 ID"),
+                                fieldWithPath("projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
+                                fieldWithPath("chatRoomId").type(JsonFieldType.NUMBER).description("채팅방 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("프로젝트 참여 제안 API Docs")
+    void offer() throws Exception {
+        // given
+        ProjectApplyRequest request = ProjectApplyRequestFixture.offer();
         String requestJson = objectMapper.writeValueAsString(request);
         long projectId = 1L;
         long applyId = 1L;
@@ -72,29 +144,17 @@ class ProjectApplyControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.chatRoomId").value(chatRoomId)
                 )
                 .andDo(print())
-                .andDo(document("create-project-apply",
+                .andDo(document("project-offer",
                         resourceDetails().tag(ApiDocTag.PROJECT.getTag())
-                                .summary("프로젝트 지원")
-                                .description("""
-                                        프로젝트에 지원 또는 참여제안 API입니다.
-                                                                                
-                                        삭제된 프로젝트는 지원 불가
-                                                                                
-                                        모집완료된 프로젝트는 지원 불가
-                                                                                
-                                        프로젝트 등록자는 본인이 등록한 프로젝트에 지원 불가(지원일 경우)
-                                                                                
-                                        모집직군에 지원하는 직무가 없을 경우, 모집직군에 지원하는 직무가 마감된 경우 지원 불가
-                                                                                
-                                        이미 지원한 프로젝트는 지원 불가
-                                        """),
+                                .summary("프로젝트 참여 제안"),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
                         ),
                         requestFields(
                                 fieldWithPath("applyJob").type(JsonFieldType.STRING).description("지원 직무"),
                                 fieldWithPath("content").type(JsonFieldType.STRING).description("지원 글"),
-                                fieldWithPath("applyType").type(JsonFieldType.STRING).description("지원 타입 ( 지원 or 참여 제안 [APPLY, OFFER] )")
+                                fieldWithPath("applyType").type(JsonFieldType.STRING).description("지원 타입"),
+                                fieldWithPath("applicantId").type(JsonFieldType.NUMBER).description("지원자 ID")
                         ),
                         responseFields(
                                 fieldWithPath("applyId").type(JsonFieldType.NUMBER).description("지원 ID"),

--- a/src/test/java/com/whatpl/project/model/ProjectApplyRequestFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectApplyRequestFixture.java
@@ -1,0 +1,25 @@
+package com.whatpl.project.model;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.project.domain.enums.ApplyType;
+import com.whatpl.project.dto.ProjectApplyRequest;
+
+public class ProjectApplyRequestFixture {
+
+    public static ProjectApplyRequest apply() {
+        return ProjectApplyRequest.builder()
+                .applyJob(Job.BACKEND_DEVELOPER)
+                .content("test content")
+                .applyType(ApplyType.APPLY)
+                .build();
+    }
+
+    public static ProjectApplyRequest offer() {
+        return ProjectApplyRequest.builder()
+                .applyJob(Job.BACKEND_DEVELOPER)
+                .content("test content")
+                .applyType(ApplyType.OFFER)
+                .applicantId(1L)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/project/service/ProjectApplyServiceTest.java
+++ b/src/test/java/com/whatpl/project/service/ProjectApplyServiceTest.java
@@ -15,6 +15,7 @@ import com.whatpl.project.domain.enums.ApplyType;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.dto.ProjectApplyRequest;
 import com.whatpl.project.model.ApplyFixture;
+import com.whatpl.project.model.ProjectApplyRequestFixture;
 import com.whatpl.project.model.ProjectFixture;
 import com.whatpl.project.model.RecruitJobFixture;
 import com.whatpl.project.repository.ApplyRepository;
@@ -59,7 +60,7 @@ class ProjectApplyServiceTest {
         Project project = ProjectFixture.create();
         Member writer = MemberFixture.onlyRequired();
         project.setStatus(ProjectStatus.DELETED);
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
         when(memberRepository.findById(anyLong()))
@@ -78,7 +79,7 @@ class ProjectApplyServiceTest {
         Project project = ProjectFixture.create();
         Member writer = MemberFixture.onlyRequired();
         project.setStatus(ProjectStatus.COMPLETED);
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
         when(memberRepository.findById(anyLong()))
@@ -97,7 +98,7 @@ class ProjectApplyServiceTest {
         Member writer = MemberFixture.onlyRequired();
         project.addRepresentImageAndWriter(null, writer);
         project.setStatus(ProjectStatus.RECRUITING);
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
         when(memberRepository.findById(anyLong()))
@@ -118,7 +119,7 @@ class ProjectApplyServiceTest {
         project.setStatus(ProjectStatus.RECRUITING);
         project.addRecruitJob(new RecruitJob(Job.DESIGNER, 5));
 
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
         when(memberRepository.findById(anyLong()))
@@ -140,7 +141,7 @@ class ProjectApplyServiceTest {
         project.setStatus(ProjectStatus.RECRUITING);
         project.addRecruitJob(new RecruitJob(Job.BACKEND_DEVELOPER, recruitAmount));
 
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
         when(memberRepository.findById(anyLong()))
@@ -163,7 +164,7 @@ class ProjectApplyServiceTest {
         project.setStatus(ProjectStatus.RECRUITING);
         project.addRecruitJob(new RecruitJob(Job.BACKEND_DEVELOPER, 5));
 
-        ProjectApplyRequest request = new ProjectApplyRequest(Job.BACKEND_DEVELOPER, "test content", ApplyType.APPLY);
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
         when(memberRepository.findById(anyLong()))


### PR DESCRIPTION
## #️⃣연관된 이슈

- #52 
- #32

## 📝작업 내용

- 프로젝트 모집자가 다른 사용자에게 본인의 프로젝트에 참여할 것을 제안하는 기능 구현
- 지원/참여 제안 두개의 API를 분리할까 생각했지만, Resource가 명확해지지 않을 것 같다는 판단에 같은 API를 사용했습니다. (요청 body의 applyType으로 지원/참여 제안을 구분합니다.)
- 지원서 관련 API의 권한 체크를 추가했습니다.
  - 지원은 아무나, 참여제안은 프로젝트 모집자만
  - 지원서 상태변경은 지원일 경우 모집자만, 참여 제안일 경우 지원자만
