### PR TITLE
모집된 팀원 제외

### DIFF
--- a/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
@@ -21,6 +21,7 @@ public class MethodSecurityConfig {
     private final ApplyPermissionManager applyPermissionManager;
     private final ProjectCommentPermissionManager projectCommentPermissionManager;
     private final ProjectLikePermissionManager projectLikePermissionManager;
+    private final ParticipantPermissionManager participantPermissionManager;
     private final ChatMessagePermissionManager chatMessagePermissionManager;
 
     @Bean
@@ -29,6 +30,7 @@ public class MethodSecurityConfig {
         whatplPermissionEvaluatorMap.put("APPLY", applyPermissionManager);
         whatplPermissionEvaluatorMap.put("PROJECT_COMMENT", projectCommentPermissionManager);
         whatplPermissionEvaluatorMap.put("PROJECT_LIKE", projectLikePermissionManager);
+        whatplPermissionEvaluatorMap.put("PARTICIPANT", participantPermissionManager);
         whatplPermissionEvaluatorMap.put("CHAT_MESSAGE", chatMessagePermissionManager);
 
         DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -37,6 +37,9 @@ public enum ErrorCode {
     NOT_FOUND_PARENT_PROJECT_COMMENT("PRJ11", 404, "상위 댓글을 찾을 수 없습니다."),
     NOT_FOUND_PROJECT_COMMENT("PRJ12", 404, "댓글을 찾을 수 없습니다."),
     NOT_MATCH_PROJECT_LIKE("PRJ13", 400, "프로젝트 ID와 좋아요 ID가 일치하지 않습니다."),
+    NOT_FOUND_PROJECT_PARTICIPANT("PRJ14", 404, "프로젝트 참여자를 찾을 수 없습니다."),
+    NOT_MATCH_PROJECT_PARTICIPANT("PRJ15", 400, "프로젝트 ID와 참여자 ID가 일치하지 않습니다."),
+    CANT_PROCESS_EXCLUDED("PRJ16", 400, "프로젝트 지원서를 제외 상태로 변경할 수 없습니다."),
 
     // APPLY
     NOT_FOUND_APPLY("APL1", 404, "지원정보를 찾을 수 없습니다."),

--- a/src/main/java/com/whatpl/global/security/permission/manager/ParticipantPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/ParticipantPermissionManager.java
@@ -1,0 +1,37 @@
+package com.whatpl.global.security.permission.manager;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.domain.ProjectParticipant;
+import com.whatpl.project.repository.ProjectParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantPermissionManager implements WhatplPermissionManager {
+
+    private final ProjectParticipantRepository projectParticipantRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission) {
+        return switch (permission) {
+            case "DELETE" -> hasDeletePrivilege(memberPrincipal, targetId);
+            default -> false;
+        };
+    }
+
+    /**
+     * 프로젝트 참여자 삭제 권한
+     * 프로젝트 등록자
+     */
+    private boolean hasDeletePrivilege(MemberPrincipal memberPrincipal, Long participantId) {
+        ProjectParticipant projectParticipant = projectParticipantRepository.findWithAllById(participantId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT_PARTICIPANT));
+        Long recruiterId = projectParticipant.getProject().getWriter().getId();
+        return recruiterId.equals(memberPrincipal.getId());
+    }
+}

--- a/src/main/java/com/whatpl/project/controller/ProjectApplyController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectApplyController.java
@@ -47,6 +47,9 @@ public class ProjectApplyController {
         if (ApplyStatus.WAITING.equals(request.getApplyStatus())) {
             throw new BizException(ErrorCode.CANT_PROCESS_WAITING);
         }
+        if (ApplyStatus.EXCLUDED.equals(request.getApplyStatus())) {
+            throw new BizException(ErrorCode.CANT_PROCESS_EXCLUDED);
+        }
         projectApplyService.status(projectId, applyId, request.getApplyStatus());
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/whatpl/project/controller/ProjectParticipantController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectParticipantController.java
@@ -1,0 +1,24 @@
+package com.whatpl.project.controller;
+
+import com.whatpl.project.service.ProjectParticipantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProjectParticipantController {
+
+    private final ProjectParticipantService projectParticipantService;
+
+    @PreAuthorize("hasPermission(#participantId, 'PARTICIPANT', 'DELETE')")
+    @DeleteMapping("/projects/{projectId}/participants/{participantId}")
+    public ResponseEntity<Void> delete(@PathVariable long projectId,
+                                       @PathVariable long participantId) {
+        projectParticipantService.deleteParticipant(projectId, participantId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
@@ -133,6 +133,7 @@ public final class ProjectModelConverter {
         return projectParticipants.stream()
                 .filter(projectParticipant -> projectParticipant.getJob().equals(job))
                 .map(projectParticipant -> ProjectJobParticipantDto.ParticipantDto.builder()
+                        .participantId(projectParticipant.getId())
                         .memberId(projectParticipant.getParticipant().getId())
                         .nickname(projectParticipant.getParticipant().getNickname())
                         .career(projectParticipant.getParticipant().getCareer())

--- a/src/main/java/com/whatpl/project/domain/Apply.java
+++ b/src/main/java/com/whatpl/project/domain/Apply.java
@@ -61,7 +61,7 @@ public class Apply extends BaseTimeEntity {
 
     //==비즈니스 로직==//
     public void changeStatus(ApplyStatus status) {
-        if (!ApplyStatus.WAITING.equals(getStatus())) {
+        if (!ApplyStatus.WAITING.equals(getStatus()) && !ApplyStatus.EXCLUDED.equals(status)) {
             // 이미 처리된 지원서는 수정 불가
             throw new BizException(ErrorCode.ALREADY_PROCESSED_APPLY);
         }

--- a/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
+++ b/src/main/java/com/whatpl/project/domain/enums/ApplyStatus.java
@@ -15,7 +15,8 @@ public enum ApplyStatus {
 
     WAITING("승인 대기"),
     ACCEPTED("승인 완료"),
-    REJECTED("승인 거절");
+    REJECTED("승인 거절"),
+    EXCLUDED("제외");
 
     @JsonValue
     private final String value;

--- a/src/main/java/com/whatpl/project/dto/ProjectJobParticipantDto.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectJobParticipantDto.java
@@ -22,7 +22,8 @@ public class ProjectJobParticipantDto {
     @Builder
     @RequiredArgsConstructor
     public static class ParticipantDto {
-        private final Long memberId;
+        private final long participantId;
+        private final long memberId;
         private final String nickname;
         private final Career career;
     }

--- a/src/main/java/com/whatpl/project/repository/ApplyRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ApplyRepository.java
@@ -3,6 +3,7 @@ package com.whatpl.project.repository;
 import com.whatpl.member.domain.Member;
 import com.whatpl.project.domain.Apply;
 import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.enums.ApplyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +15,7 @@ public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     @Query("select a from Apply a left join fetch a.project left join fetch a.applicant where a.id = :id")
     Optional<Apply> findWithProjectAndApplicantById(Long id);
+
+    @Query("select a from Apply a where a.applicant = :applicant and a.status = :status")
+    Optional<Apply> findByApplicantAndStatus(Member applicant, ApplyStatus status);
 }

--- a/src/main/java/com/whatpl/project/repository/ProjectParticipantRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectParticipantRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectParticipantRepository extends JpaRepository<ProjectParticipant, Long> {
 
@@ -13,4 +14,7 @@ public interface ProjectParticipantRepository extends JpaRepository<ProjectParti
     List<ProjectParticipant> findAllByProjectId(Long projectId);
 
     int countByProjectIdAndJob(Long projectId, Job job);
+
+    @EntityGraph(attributePaths = {"project", "participant"})
+    Optional<ProjectParticipant> findWithAllById(Long participantId);
 }

--- a/src/main/java/com/whatpl/project/service/ProjectParticipantService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectParticipantService.java
@@ -1,0 +1,38 @@
+package com.whatpl.project.service;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.ProjectParticipant;
+import com.whatpl.project.domain.enums.ApplyStatus;
+import com.whatpl.project.repository.ApplyRepository;
+import com.whatpl.project.repository.ProjectParticipantRepository;
+import com.whatpl.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectParticipantService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectParticipantRepository projectParticipantRepository;
+    private final ApplyRepository applyRepository;
+
+    @Transactional
+    public void deleteParticipant(final long projectId, final long participantId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        ProjectParticipant projectParticipant = projectParticipantRepository.findWithAllById(participantId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT_PARTICIPANT));
+        if (!project.getId().equals(projectParticipant.getProject().getId())) {
+            throw new BizException(ErrorCode.NOT_MATCH_PROJECT_PARTICIPANT);
+        }
+        // 지원서의 상태를 승인 -> 제외로 변경
+        applyRepository.findByApplicantAndStatus(projectParticipant.getParticipant(), ApplyStatus.ACCEPTED)
+                .ifPresent(apply -> apply.changeStatus(ApplyStatus.EXCLUDED));
+
+        projectParticipantRepository.delete(projectParticipant);
+    }
+}

--- a/src/test/java/com/whatpl/ApiDocTag.java
+++ b/src/test/java/com/whatpl/ApiDocTag.java
@@ -13,6 +13,7 @@ public enum ApiDocTag {
     PROJECT_COMMENT("Project Comments"),
     PROJECT_LIKE("Project Likes"),
     PROJECT_APPLY("Project Apply"),
+    PROJECT_PARTICIPANT("Project Participants"),
     ATTACHMENT("Attachments"),
     CHAT("Chats"),
     DOMAIN("Domains");

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -71,6 +71,9 @@ public abstract class BaseSecurityWebMvcTest {
     @MockBean
     protected ChatService chatService;
 
+    @MockBean
+    protected ProjectParticipantService projectParticipantService;
+
     @BeforeEach
     protected void init() {
         when(jwtProperties.getTokenType()).thenReturn("Bearer");

--- a/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
@@ -114,12 +114,16 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.projectJobParticipants[0].job").value(response.getProjectJobParticipants().get(0).getJob().getValue()),
                         jsonPath("$.projectJobParticipants[0].recruitAmount").value(response.getProjectJobParticipants().get(0).getRecruitAmount()),
                         jsonPath("$.projectJobParticipants[0].participantAmount").value(response.getProjectJobParticipants().get(0).getParticipantAmount()),
+                        jsonPath("$.projectJobParticipants[0].participants[0].participantId")
+                                                        .value(response.getProjectJobParticipants().get(0).getParticipants().get(0).getParticipantId()),
                         jsonPath("$.projectJobParticipants[0].participants[0].memberId")
                                 .value(response.getProjectJobParticipants().get(0).getParticipants().get(0).getMemberId()),
                         jsonPath("$.projectJobParticipants[0].participants[0].nickname")
                                 .value(response.getProjectJobParticipants().get(0).getParticipants().get(0).getNickname()),
                         jsonPath("$.projectJobParticipants[0].participants[0].career")
                                 .value(response.getProjectJobParticipants().get(0).getParticipants().get(0).getCareer().getValue()),
+                        jsonPath("$.projectJobParticipants[0].participants[1].participantId")
+                                                        .value(response.getProjectJobParticipants().get(0).getParticipants().get(1).getParticipantId()),
                         jsonPath("$.projectJobParticipants[0].participants[1].memberId")
                                 .value(response.getProjectJobParticipants().get(0).getParticipants().get(1).getMemberId()),
                         jsonPath("$.projectJobParticipants[0].participants[1].nickname")
@@ -160,7 +164,8 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("projectJobParticipants[].recruitAmount").type(JsonFieldType.NUMBER).description("모집 인원수"),
                                 fieldWithPath("projectJobParticipants[].participantAmount").type(JsonFieldType.NUMBER).description("참여자 인원수"),
                                 fieldWithPath("projectJobParticipants[].participants").type(JsonFieldType.ARRAY).description("참여자"),
-                                fieldWithPath("projectJobParticipants[].participants[].memberId").type(JsonFieldType.NUMBER).description("참여자 ID"),
+                                fieldWithPath("projectJobParticipants[].participants[].participantId").type(JsonFieldType.NUMBER).description("참여 ID = 테이블 PK"),
+                                fieldWithPath("projectJobParticipants[].participants[].memberId").type(JsonFieldType.NUMBER).description("참여자 ID = 멤버 ID"),
                                 fieldWithPath("projectJobParticipants[].participants[].nickname").type(JsonFieldType.STRING).description("닉네임"),
                                 fieldWithPath("projectJobParticipants[].participants[].career").type(JsonFieldType.STRING).description("경력")
                         )

--- a/src/test/java/com/whatpl/project/controller/ProjectParticipantControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectParticipantControllerTest.java
@@ -1,0 +1,66 @@
+package com.whatpl.project.controller;
+
+import com.whatpl.ApiDocTag;
+import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.global.security.model.WithMockWhatplMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.RestDocumentationExtension;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+class ProjectParticipantControllerTest extends BaseSecurityWebMvcTest {
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("프로젝트 참여자 제외 API Docs")
+    void excludeParticipant() throws Exception {
+        // given
+        doNothing().when(projectParticipantService).deleteParticipant(anyLong(), anyLong());
+        long projectId = 1L;
+        long participantId = 1L;
+
+        // expected
+        mockMvc.perform(delete("/projects/{projectId}/participants/{participantId}", projectId, participantId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpectAll(
+                        status().isNoContent()
+                )
+                .andDo(print())
+                .andDo(document("exclude-participant",
+                        resourceDetails().tag(ApiDocTag.PROJECT_PARTICIPANT.getTag())
+                                .summary("프로젝트 참여자 제외")
+                                .description("""
+                                        프로젝트 참여자를 제외합니다.
+                                                                                
+                                        참여자를 삭제하고, 지원서의 상태를 ACCEPTED -> EXCLUDED로 변경합니다.
+                                                                                
+                                        [권한]
+                                        - 프로젝트 모집자
+                                        """),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                        ),
+                        pathParameters(
+                                parameterWithName("projectId").description("프로젝트 ID"),
+                                parameterWithName("participantId").description("참여 ID")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/whatpl/project/model/ProjectReadResponseFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectReadResponseFixture.java
@@ -40,12 +40,14 @@ public class ProjectReadResponseFixture {
                                 .participantAmount(2)
                                 .participants(List.of(
                                         ProjectJobParticipantDto.ParticipantDto.builder()
-                                                .memberId(1L)
+                                                .participantId(1L)
+                                                .memberId(11L)
                                                 .nickname("백엔드 참여자1")
                                                 .career(Career.FIVE)
                                                 .build(),
                                         ProjectJobParticipantDto.ParticipantDto.builder()
-                                                .memberId(2L)
+                                                .participantId(2L)
+                                                .memberId(22L)
                                                 .nickname("백엔드 참여자2")
                                                 .career(Career.NONE)
                                                 .build()))

--- a/src/test/java/com/whatpl/project/service/ProjectParticipantServiceTest.java
+++ b/src/test/java/com/whatpl/project/service/ProjectParticipantServiceTest.java
@@ -1,0 +1,69 @@
+package com.whatpl.project.service;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.model.MemberFixture;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.ProjectParticipant;
+import com.whatpl.project.domain.enums.ApplyStatus;
+import com.whatpl.project.model.ApplyFixture;
+import com.whatpl.project.model.ProjectFixture;
+import com.whatpl.project.repository.ApplyRepository;
+import com.whatpl.project.repository.ProjectParticipantRepository;
+import com.whatpl.project.repository.ProjectRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectParticipantServiceTest {
+
+    @InjectMocks
+    ProjectParticipantService projectParticipantService;
+
+    @Mock
+    ProjectRepository projectRepository;
+
+    @Mock
+    ProjectParticipantRepository projectParticipantRepository;
+
+    @Mock
+    ApplyRepository applyRepository;
+
+    @Test
+    @DisplayName("프로젝트 참여자 삭제 시 참여자가 삭제되고, Apply 가 제외상태로 변경된다.")
+    void deleteParticipant() {
+        // given
+        Member participant = Mockito.spy(MemberFixture.onlyRequired());
+        Project project = Mockito.spy(ProjectFixture.create());
+        ProjectParticipant projectParticipant = ProjectParticipant.builder()
+                .job(Job.BACKEND_DEVELOPER)
+                .project(project)
+                .participant(participant)
+                .build();
+        Apply apply = ApplyFixture.accepted(projectParticipant.getJob(), participant, project);
+        when(participant.getId()).thenReturn(1L);
+        when(project.getId()).thenReturn(1L);
+        when(projectRepository.findById(anyLong())).thenReturn(Optional.of(project));
+        when(projectParticipantRepository.findWithAllById(anyLong())).thenReturn(Optional.of(projectParticipant));
+        when(applyRepository.findByApplicantAndStatus(projectParticipant.getParticipant(), ApplyStatus.ACCEPTED))
+                .thenReturn(Optional.of(apply));
+
+        // when
+        projectParticipantService.deleteParticipant(project.getId(), participant.getId());
+
+        // then
+        verify(projectParticipantRepository, times(1)).delete(projectParticipant);
+        assertEquals(ApplyStatus.EXCLUDED, apply.getStatus());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #56
- #35

## 📝작업 내용

- 프로젝트에 지원 후 프로젝트에 참여한 사용자를 프로젝트에서 제외하는 기능을 구현했습니다.
- 참여자 제외 API는 프로젝트 모집자만 접근 가능합니다.
- 참여자 삭제 후 지원서의 상태를 ACCEPTED(승인 완료) -> EXCLUDED(제외)로 변경하도록 구현했습니다. (나중에 채팅방에서 지원상태 확인할 때 필요할 듯 합니다.)
- 프로젝트 조회 API 호출 시 participantId 응답을 추가했습니다.
  - 지원자 제외 API에 participantId가 요청path에 포함되어야 하기 때문