### PR TITLE
프로젝트 리스트 검색

### DIFF
--- a/src/main/java/com/whatpl/global/config/SecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         .requestMatchers(WEB_SECURITY_WHITE_LIST).permitAll()
                         .requestMatchers(HttpMethod.GET, "/attachments/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/projects/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/projects/search/**").permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo

--- a/src/main/java/com/whatpl/global/config/SecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.*;
 
@@ -45,7 +46,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                         .requestMatchers(WEB_SECURITY_WHITE_LIST).permitAll()
                         .requestMatchers(HttpMethod.GET, "/attachments/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/projects/{projectId}/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/projects/**").permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
@@ -58,7 +59,7 @@ public class SecurityConfig {
                         SecurityContextHolderFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(handler -> handler
                         .authenticationEntryPoint(new NoAuthenticationHandler(objectMapper))
                         .accessDeniedHandler(new NoAuthorizationHandler(objectMapper)));

--- a/src/main/java/com/whatpl/project/controller/ProjectLikeController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectLikeController.java
@@ -19,7 +19,7 @@ public class ProjectLikeController {
     private final ProjectLikeService projectLikeService;
 
     @PutMapping("/projects/{projectId}/likes")
-    public ResponseEntity<?> putLike(@PathVariable long projectId,
+    public ResponseEntity<ProjectLikeResponse> putLike(@PathVariable long projectId,
                                      @AuthenticationPrincipal MemberPrincipal principal) {
         long likeId = projectLikeService.putLike(projectId, principal.getId());
         return ResponseEntity.ok(ProjectLikeResponse.builder()

--- a/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
@@ -90,7 +90,7 @@ public final class ProjectModelConverter {
         return project;
     }
 
-    public static ProjectReadResponse toProjectReadResponse(Project project, List<ProjectParticipant> projectParticipants, long likes) {
+    public static ProjectReadResponse toProjectReadResponse(Project project, List<ProjectParticipant> projectParticipants, long likes, boolean myLike) {
         return ProjectReadResponse.builder()
                 .projectId(project.getId())
                 .title(project.getTitle())
@@ -117,6 +117,7 @@ public final class ProjectModelConverter {
                                 .build()
                         )
                         .toList())
+                .myLike(myLike)
                 .build();
     }
 

--- a/src/main/java/com/whatpl/project/domain/Project.java
+++ b/src/main/java/com/whatpl/project/domain/Project.java
@@ -52,6 +52,15 @@ public class Project extends BaseTimeEntity {
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RecruitJob> recruitJobs = new HashSet<>();
 
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ProjectComment> projectComments = new HashSet<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ProjectLike> projectLikes = new HashSet<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ProjectParticipant> projectParticipants = new HashSet<>();
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "represent_image_id")
     private Attachment representImage;

--- a/src/main/java/com/whatpl/project/dto/ProjectInfo.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectInfo.java
@@ -6,7 +6,6 @@ import com.whatpl.global.pagination.SliceElement;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import lombok.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -19,14 +18,14 @@ public class ProjectInfo implements SliceElement {
     private ProjectStatus status;
     private Subject subject;
     @Setter
-    private List<Skill> skills = new ArrayList<>();
+    private List<Skill> skills;
     @Setter
-    private List<RemainedJobDto> remainedJobs = new ArrayList<>();
+    private List<RemainedJobDto> remainedJobs;
     private boolean profitable;
-    private long views;
+    private int views;
     @Setter
-    private long likes;
+    private int likes;
     @Setter
-    private long comments;
+    private int comments;
     private String representImageUri;
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectInfo.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectInfo.java
@@ -17,6 +17,7 @@ public class ProjectInfo implements SliceElement {
     private String title;
     private ProjectStatus status;
     private Subject subject;
+    private boolean myLike;
     @Setter
     private List<Skill> skills;
     @Setter

--- a/src/main/java/com/whatpl/project/dto/ProjectInfo.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectInfo.java
@@ -1,0 +1,32 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Skill;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.global.pagination.SliceElement;
+import com.whatpl.project.domain.enums.ProjectStatus;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectInfo implements SliceElement {
+    private long projectId;
+    private String title;
+    private ProjectStatus status;
+    private Subject subject;
+    @Setter
+    private List<Skill> skills = new ArrayList<>();
+    @Setter
+    private List<RemainedJobDto> remainedJobs = new ArrayList<>();
+    private boolean profitable;
+    private long views;
+    @Setter
+    private long likes;
+    @Setter
+    private long comments;
+    private String representImageUri;
+}

--- a/src/main/java/com/whatpl/project/dto/ProjectReadResponse.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectReadResponse.java
@@ -32,4 +32,5 @@ public class ProjectReadResponse {
     private final LocalDate startDate;
     private final LocalDate endDate;
     private final List<ProjectJobParticipantDto> projectJobParticipants;
+    private final boolean myLike;
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
@@ -1,0 +1,21 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.common.domain.enums.Skill;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.project.domain.enums.ProjectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProjectSearchCondition {
+    private Subject subject;
+    private Job job;
+    private Skill skill;
+    private ProjectStatus status;
+    private Boolean profitable;
+    private String keyword;
+}

--- a/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
@@ -1,5 +1,6 @@
 package com.whatpl.project.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.common.domain.enums.Skill;
 import com.whatpl.global.common.domain.enums.Subject;
@@ -7,6 +8,7 @@ import com.whatpl.project.domain.enums.ProjectStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Builder
@@ -18,4 +20,7 @@ public class ProjectSearchCondition {
     private ProjectStatus status;
     private Boolean profitable;
     private String keyword;
+    @Setter
+    @JsonIgnore
+    private long longinMemberId;
 }

--- a/src/main/java/com/whatpl/project/dto/RemainedJobDto.java
+++ b/src/main/java/com/whatpl/project/dto/RemainedJobDto.java
@@ -1,0 +1,20 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Job;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RemainedJobDto {
+
+    private final Job job;
+    private final int recruitAmount;
+    private final int remainedAmount;
+
+    @Builder
+    public RemainedJobDto(Job job, int recruitAmount, int remainedAmount) {
+        this.job = job;
+        this.recruitAmount = recruitAmount;
+        this.remainedAmount = remainedAmount;
+    }
+}

--- a/src/main/java/com/whatpl/project/repository/ProjectLikeRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectLikeRepository.java
@@ -15,4 +15,6 @@ public interface ProjectLikeRepository extends JpaRepository<ProjectLike, Long> 
     Optional<ProjectLike> findWithMemberById(Long memberId);
 
     long countByProject(Project project);
+
+    boolean existsByProjectIdAndMemberId(Long projectId, Long memberId);
 }

--- a/src/main/java/com/whatpl/project/repository/ProjectQueryRepository.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectQueryRepository.java
@@ -1,9 +1,16 @@
 package com.whatpl.project.repository;
 
 import com.whatpl.project.domain.Project;
+import com.whatpl.project.dto.ProjectInfo;
+import com.whatpl.project.dto.ProjectSearchCondition;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
 public interface ProjectQueryRepository {
+
     Optional<Project> findProjectWithAllById(Long id);
+
+    Slice<ProjectInfo> search(Pageable pageable, ProjectSearchCondition searchCondition);
 }

--- a/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
@@ -1,19 +1,43 @@
 package com.whatpl.project.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.whatpl.project.domain.Project;
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.common.domain.enums.Skill;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.global.util.PaginationUtils;
+import com.whatpl.project.domain.*;
+import com.whatpl.project.domain.enums.ProjectStatus;
+import com.whatpl.project.dto.ProjectInfo;
+import com.whatpl.project.dto.ProjectSearchCondition;
+import com.whatpl.project.dto.RemainedJobDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.util.StringUtils;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static com.querydsl.core.types.Projections.fields;
+import static com.querydsl.jpa.JPAExpressions.select;
 import static com.whatpl.attachment.domain.QAttachment.attachment;
 import static com.whatpl.member.domain.QMember.member;
 import static com.whatpl.project.domain.QProject.project;
+import static com.whatpl.project.domain.QProjectComment.projectComment;
+import static com.whatpl.project.domain.QProjectLike.projectLike;
+import static com.whatpl.project.domain.QProjectParticipant.projectParticipant;
 import static com.whatpl.project.domain.QProjectSkill.projectSkill;
 import static com.whatpl.project.domain.QRecruitJob.recruitJob;
+import static java.util.stream.Collectors.groupingBy;
 
 @RequiredArgsConstructor
-public class ProjectQueryRepositoryImpl implements ProjectQueryRepository{
+public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
@@ -27,5 +51,163 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository{
                 .where(project.id.eq(id))
                 .fetchOne();
         return Optional.ofNullable(resultProject);
+    }
+
+    @Override
+    public Slice<ProjectInfo> search(Pageable pageable, ProjectSearchCondition searchCondition) {
+        int pageSize = pageable.getPageSize();
+        // Project (루트) 조회
+        List<ProjectInfo> projectInfos = findProjectInfos(pageable, searchCondition);
+        List<Long> projectIds = toProjectIds(projectInfos);
+        // ProjectSkill (1:N) 조회
+        Map<Long, List<ProjectSkill>> projectSkillMap = findProjectSkillMap(projectIds);
+        // RecruitJob (1:N) 조회
+        Map<Long, List<RecruitJob>> recruitJobMap = findRecruitJobMap(projectIds);
+        // ProjectParticipant (1:N) 조회
+        Map<Long, List<ProjectParticipant>> participantMap = findParticipantMap(projectIds);
+        // ProjectLike (1:N) 조회
+        Map<Long, List<ProjectLike>> projectLikeMap = findProjectLikeMap(projectIds);
+        // ProjectComment (1:N) 조회
+        Map<Long, List<ProjectComment>> projectCommentMap = findProjectCommentMap(projectIds);
+
+        projectInfos.forEach(projectInfo -> {
+            long projectId = projectInfo.getProjectId();
+            // 기술 스택 추가
+            projectInfo.setSkills(projectSkillMap.get(projectId).stream()
+                    .map(ProjectSkill::getSkill).toList());
+            // 모집이 완료되지 않은 직무 추가
+            List<RecruitJob> recruitJobs = recruitJobMap.get(projectId);
+            List<ProjectParticipant> participants = Optional.ofNullable(participantMap.get(projectId)).orElseGet(Collections::emptyList);
+            List<RemainedJobDto> remainedJobs = recruitJobs.stream()
+                    .map(recruitJob -> RemainedJobDto.builder()
+                            .job(recruitJob.getJob())
+                            .recruitAmount(recruitJob.getRecruitAmount())
+                            .remainedAmount(recruitJobs.size() - participants.size())
+                            .build())
+                    .filter(remainedJob -> remainedJob.getRemainedAmount() != 0)
+                    .toList();
+            projectInfo.setRemainedJobs(remainedJobs);
+            // 좋아요 갯수 추가
+            projectInfo.setLikes(Optional.ofNullable(projectLikeMap.get(projectId)).orElseGet(Collections::emptyList).size());
+            // 댓글 갯수 추가
+            projectInfo.setComments(Optional.ofNullable(projectCommentMap.get(projectId)).orElseGet(Collections::emptyList).size());
+        });
+
+        return new SliceImpl<>(projectInfos, pageable, PaginationUtils.hasNext(projectInfos, pageable.getPageSize()));
+    }
+
+    private List<ProjectInfo> findProjectInfos(Pageable pageable, ProjectSearchCondition searchCondition) {
+        return queryFactory.select(fields(ProjectInfo.class,
+                        project.id.as("projectId"),
+                        project.title.as("title"),
+                        project.status.as("status"),
+                        project.subject.as("subject"),
+                        project.profitable.as("profitable"),
+                        project.views.as("vies"),
+                        buildRepresentImageUri()
+                ))
+                .from(project, project)
+                .where(subjectEq(searchCondition.getSubject()),
+                        jobEq(searchCondition.getJob(), searchCondition.getStatus()),
+                        skillEq(searchCondition.getSkill()),
+                        statusEq(searchCondition.getStatus()),
+                        profitableEq(searchCondition.getProfitable()),
+                        titleLike(searchCondition.getKeyword())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(project.createdAt.desc())
+                .fetch();
+    }
+
+    private Map<Long, List<ProjectSkill>> findProjectSkillMap(List<Long> projectIds) {
+        List<ProjectSkill> projectSkills = queryFactory.selectFrom(projectSkill)
+                .where(projectSkill.project.id.in(projectIds))
+                .fetch();
+        return projectSkills.stream()
+                .collect(groupingBy(projectSkill -> projectSkill.getProject().getId()));
+    }
+
+    private Map<Long, List<RecruitJob>> findRecruitJobMap(List<Long> projectIds) {
+        List<RecruitJob> recruitJobs = queryFactory.selectFrom(recruitJob)
+                .where(recruitJob.project.id.in(projectIds))
+                .fetch();
+        return recruitJobs.stream()
+                .collect(groupingBy(recruitJob -> recruitJob.getProject().getId()));
+    }
+
+    private Map<Long, List<ProjectParticipant>> findParticipantMap(List<Long> projectIds) {
+        List<ProjectParticipant> projectParticipants = queryFactory.selectFrom(projectParticipant)
+                .where(projectParticipant.project.id.in(projectIds))
+                .fetch();
+        return projectParticipants.stream()
+                .collect(groupingBy(participant -> participant.getProject().getId()));
+    }
+
+    private Map<Long, List<ProjectLike>> findProjectLikeMap(List<Long> projectIds) {
+        List<ProjectLike> projectLikes = queryFactory.selectFrom(projectLike)
+                .where(projectLike.project.id.in(projectIds))
+                .fetch();
+        return projectLikes.stream()
+                .collect(groupingBy(projectLike -> projectLike.getProject().getId()));
+    }
+
+    private Map<Long, List<ProjectComment>> findProjectCommentMap(List<Long> projectIds) {
+        List<ProjectComment> projectComments = queryFactory.selectFrom(projectComment)
+                .where(projectComment.project.id.in(projectIds))
+                .fetch();
+        return projectComments.stream()
+                .collect(groupingBy(projectComment -> projectComment.getProject().getId()));
+    }
+
+    private StringExpression buildRepresentImageUri() {
+        return new CaseBuilder()
+                .when(project.representImage.isNull())
+                .then("/images/default?type=project")
+                .otherwise(project.representImage.id.stringValue().prepend("/attachments/").concat("/images")).as("representImageUri");
+    }
+
+    private List<Long> toProjectIds(List<ProjectInfo> projectInfos) {
+        return projectInfos.stream()
+                .map(ProjectInfo::getProjectId)
+                .toList();
+    }
+
+    private BooleanExpression subjectEq(Subject subject) {
+        return subject != null ? project.subject.eq(subject) : null;
+    }
+
+    private BooleanExpression jobEq(Job job, ProjectStatus status) {
+        if (job != null && ProjectStatus.RECRUITING.equals(status)) {
+            // 모집중인 직무 -> Job eq && 참여자 수 < 모집 인원
+            return select(projectParticipant.count())
+                    .from(projectParticipant)
+                    .where(projectParticipant.job.eq(job),
+                            projectParticipant.project.eq(project))
+                    .lt(select(recruitJob.recruitAmount.longValue())
+                            .from(recruitJob)
+                            .where(recruitJob.job.eq(job),
+                                    recruitJob.project.eq(project)));
+        } else if (job != null && status == null) {
+            // 전체 직무
+            project.recruitJobs.any().job.eq(job);
+        }
+        return null;
+    }
+
+    private BooleanExpression skillEq(Skill skill) {
+        return skill != null ? project.projectSkills.any().skill.eq(skill) : null;
+    }
+
+    private BooleanExpression statusEq(ProjectStatus status) {
+        return status != null ? project.status.eq(status) : null;
+    }
+
+    private BooleanExpression profitableEq(Boolean profitable) {
+        return profitable != null ? project.profitable.eq(profitable) : null;
+    }
+
+    private BooleanExpression titleLike(String keyword) {
+        return StringUtils.hasText(keyword) ? project.title.contains(keyword) : null;
     }
 }

--- a/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
@@ -27,6 +27,7 @@ import java.util.*;
 
 import static com.querydsl.core.types.Projections.fields;
 import static com.querydsl.jpa.JPAExpressions.select;
+import static com.querydsl.jpa.JPAExpressions.selectFrom;
 import static com.whatpl.attachment.domain.QAttachment.attachment;
 import static com.whatpl.member.domain.QMember.member;
 import static com.whatpl.project.domain.QProject.project;
@@ -104,9 +105,10 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
                         project.subject.as("subject"),
                         project.profitable.as("profitable"),
                         project.views.as("vies"),
-                        buildRepresentImageUri()
+                        buildRepresentImageUri(),
+                        myLikeExists(searchCondition).as("myLike")
                 ))
-                .from(project, project)
+                .from(project)
                 .where(subjectEq(searchCondition.getSubject()),
                         jobEq(searchCondition.getJob(), searchCondition.getStatus()),
                         skillEq(searchCondition.getSkill()),
@@ -230,5 +232,12 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
 
     private BooleanExpression titleLike(String keyword) {
         return StringUtils.hasText(keyword) ? project.title.contains(keyword) : null;
+    }
+
+    private BooleanExpression myLikeExists(ProjectSearchCondition searchCondition) {
+        return selectFrom(projectLike)
+                .where(projectLike.project.eq(project),
+                        projectLike.member.id.eq(searchCondition.getLonginMemberId()))
+                .exists();
     }
 }

--- a/src/main/java/com/whatpl/project/service/ProjectReadService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectReadService.java
@@ -5,11 +5,15 @@ import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.project.converter.ProjectModelConverter;
 import com.whatpl.project.domain.Project;
 import com.whatpl.project.domain.ProjectParticipant;
+import com.whatpl.project.dto.ProjectInfo;
 import com.whatpl.project.dto.ProjectReadResponse;
+import com.whatpl.project.dto.ProjectSearchCondition;
 import com.whatpl.project.repository.ProjectLikeRepository;
 import com.whatpl.project.repository.ProjectParticipantRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,5 +37,10 @@ public class ProjectReadService {
         // 조회수 증가
         project.increaseViews();
         return ProjectModelConverter.toProjectReadResponse(project, participants, likes);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ProjectInfo> searchProjectList(Pageable pageable, ProjectSearchCondition searchCondition) {
+        return projectRepository.search(pageable, searchCondition);
     }
 }

--- a/src/main/java/com/whatpl/project/service/ProjectReadService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectReadService.java
@@ -28,15 +28,16 @@ public class ProjectReadService {
     private final ProjectLikeRepository projectLikeRepository;
 
     @Transactional
-    public ProjectReadResponse readProject(final long projectId) {
+    public ProjectReadResponse readProject(final long projectId, final long memberId) {
         Project project = projectRepository.findProjectWithAllById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
         List<ProjectParticipant> participants = projectParticipantRepository.findAllByProjectId(project.getId());
+        boolean myLike = projectLikeRepository.existsByProjectIdAndMemberId(projectId, memberId);
 
         long likes = projectLikeRepository.countByProject(project);
         // 조회수 증가
         project.increaseViews();
-        return ProjectModelConverter.toProjectReadResponse(project, participants, likes);
+        return ProjectModelConverter.toProjectReadResponse(project, participants, likes, myLike);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/whatpl/BaseRepositoryTest.java
+++ b/src/test/java/com/whatpl/BaseRepositoryTest.java
@@ -1,6 +1,9 @@
 package com.whatpl;
 
 import com.whatpl.global.config.JpaConfig;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -8,5 +11,9 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @Import(JpaConfig.class)
 @ActiveProfiles(profiles = "test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // @DataJpaTest에서 제공하는 테스트용 DB 사용 X -> application-test.yml에서 정의한 데이터소스 사용
 public abstract class BaseRepositoryTest {
+
+    @Autowired
+    protected EntityManager em;
 }

--- a/src/test/java/com/whatpl/member/repository/MemberQueryRepositoryImplTest.java
+++ b/src/test/java/com/whatpl/member/repository/MemberQueryRepositoryImplTest.java
@@ -5,7 +5,6 @@ import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.model.MemberFixture;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +16,6 @@ class MemberQueryRepositoryImplTest extends BaseRepositoryTest {
 
     @Autowired
     MemberRepository memberRepository;
-
-    @Autowired
-    EntityManager em;
 
     @Test
     @DisplayName("Member를 조회할 때 기술스택, 포트폴리오, 참고링크, 관심주제 모두 조회(Fetch Join)")

--- a/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
@@ -185,6 +185,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
         // given
         int page = 1;
         int size = 2;
+        String sort = "popular";
         ProjectInfo projectInfo = ProjectInfo.builder()
                 .projectId(1L)
                 .title("테스트 프로젝트 1")
@@ -217,6 +218,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
         mockMvc.perform(post("/projects/search")
                         .param("page", String.valueOf(page))
                         .param("size", String.valueOf(size))
+                        .param("sort", sort)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(searchCondition))
                 )
@@ -243,10 +245,16 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                                                                 
                                         [유효성 검증]
                                         - 요청 필드의 상태(status)값은 "모집중"만 지원합니다. (아닐 시 400 에러) (status 필드가 없으면 전체 상태 검색)
+                                        
+                                        [정렬]
+                                        - 정렬은 queryParameter의 sort값을 지정해야 합니다. 아래 2가지 정렬을 지원합니다.
+                                        - popular : 인기순
+                                        - latest : 최신순
                                         """),
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호"),
-                                parameterWithName("size").description("페이지 사이즈")
+                                parameterWithName("size").description("페이지 사이즈"),
+                                parameterWithName("sort").description("정렬 기준")
                         ),
                         requestFields(
                                 fieldWithPath("subject").type(JsonFieldType.STRING).description("프로젝트 도메인"),

--- a/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
@@ -95,7 +95,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
         // given
         long projectId = 1L;
         ProjectReadResponse response = ProjectReadResponseFixture.from(projectId);
-        when(projectReadService.readProject(projectId))
+        when(projectReadService.readProject(anyLong(), anyLong()))
                 .thenReturn(response);
 
         // expected
@@ -117,6 +117,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.skills[1]").value(response.getSkills().get(1).getValue()),
                         jsonPath("$.startDate").value(response.getStartDate().toString()),
                         jsonPath("$.endDate").value(response.getEndDate().toString()),
+                        jsonPath("$.myLike").value(response.isMyLike()),
                         jsonPath("$.projectJobParticipants[0].job").value(response.getProjectJobParticipants().get(0).getJob().getValue()),
                         jsonPath("$.projectJobParticipants[0].recruitAmount").value(response.getProjectJobParticipants().get(0).getRecruitAmount()),
                         jsonPath("$.projectJobParticipants[0].participantAmount").value(response.getProjectJobParticipants().get(0).getParticipantAmount()),
@@ -165,6 +166,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("skills").type(JsonFieldType.ARRAY).description("사용 기술 스택"),
                                 fieldWithPath("startDate").type(JsonFieldType.STRING).description("시작 일자"),
                                 fieldWithPath("endDate").type(JsonFieldType.STRING).description("종료 일자"),
+                                fieldWithPath("myLike").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                 fieldWithPath("projectJobParticipants").type(JsonFieldType.ARRAY).description("직무별 참여자 (팀원 구성)"),
                                 fieldWithPath("projectJobParticipants[].job").type(JsonFieldType.STRING).description("직무"),
                                 fieldWithPath("projectJobParticipants[].recruitAmount").type(JsonFieldType.NUMBER).description("모집 인원수"),
@@ -202,6 +204,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .likes(20)
                 .comments(5)
                 .representImageUri("/images/default?type=project")
+                .myLike(true)
                 .build();
         SliceImpl<ProjectInfo> projectInfos = new SliceImpl<>(List.of(projectInfo));
         ProjectSearchCondition searchCondition = ProjectSearchCondition.builder()
@@ -234,7 +237,8 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.list[*].views").value(projectInfo.getViews()),
                         jsonPath("$.list[*].likes").value(projectInfo.getLikes()),
                         jsonPath("$.list[*].comments").value(projectInfo.getComments()),
-                        jsonPath("$.list[*].representImageUri").value(projectInfo.getRepresentImageUri())
+                        jsonPath("$.list[*].representImageUri").value(projectInfo.getRepresentImageUri()),
+                        jsonPath("$.list[*].myLike").value(projectInfo.isMyLike())
                 )
                 .andDo(print())
                 .andDo(document("search-project-list",
@@ -280,6 +284,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("list[].likes").type(JsonFieldType.NUMBER).description("좋아요 갯수"),
                                 fieldWithPath("list[].comments").type(JsonFieldType.NUMBER).description("댓글 갯수"),
                                 fieldWithPath("list[].representImageUri").type(JsonFieldType.STRING).description("대표 이미지 URI"),
+                                fieldWithPath("list[].myLike").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                 fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),
                                 fieldWithPath("pageSize").type(JsonFieldType.NUMBER).description("페이지 사이즈"),
                                 fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),

--- a/src/test/java/com/whatpl/project/model/ProjectReadResponseFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectReadResponseFixture.java
@@ -59,6 +59,7 @@ public class ProjectReadResponseFixture {
                                 .participants(Collections.emptyList())
                                 .build()
                         ))
+                .myLike(true)
                 .build();
     }
 }

--- a/src/test/java/com/whatpl/project/repository/ProjectQueryRepositoryImplTest.java
+++ b/src/test/java/com/whatpl/project/repository/ProjectQueryRepositoryImplTest.java
@@ -1,0 +1,78 @@
+package com.whatpl.project.repository;
+
+import com.whatpl.BaseRepositoryTest;
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.common.domain.enums.Skill;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.member.domain.Member;
+import com.whatpl.member.model.MemberFixture;
+import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.project.converter.ProjectModelConverter;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.enums.ProjectStatus;
+import com.whatpl.project.dto.ProjectCreateRequest;
+import com.whatpl.project.dto.ProjectInfo;
+import com.whatpl.project.dto.ProjectSearchCondition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectQueryRepositoryImplTest extends BaseRepositoryTest {
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    void init() {
+        Member writer = MemberFixture.withAll();
+        memberRepository.save(writer);
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("1번 프로젝트")
+                .subject(Subject.SOCIAL_MEDIA)
+                .recruitJobs(Set.of(new ProjectCreateRequest.RecruitJobField(Job.BACKEND_DEVELOPER, 2)))
+                .skills(Set.of(Skill.JAVA, Skill.FIGMA))
+                .content("1번 프로젝트 내용")
+                .profitable(false)
+                .build();
+        Project project1 = ProjectModelConverter.toProject(request, writer);
+        projectRepository.save(project1);
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("프로젝트 검색")
+    void search() {
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        ProjectSearchCondition searchCondition = ProjectSearchCondition.builder()
+                .status(ProjectStatus.RECRUITING)
+                .job(Job.BACKEND_DEVELOPER)
+                .subject(Subject.SOCIAL_MEDIA)
+                .build();
+
+        // when
+        Slice<ProjectInfo> result = projectRepository.search(pageRequest, searchCondition);
+        List<ProjectInfo> projectInfos = result.getContent();
+
+        // then
+        ProjectInfo projectInfo = projectInfos.get(0);
+        assertEquals(1, projectInfos.size());
+        assertEquals(2, projectInfo.getSkills().size());
+        assertEquals(1, projectInfo.getRemainedJobs().size());
+        assertEquals(2, projectInfo.getRemainedJobs().get(0).getRecruitAmount());
+        assertEquals(1, projectInfo.getRemainedJobs().get(0).getRemainedAmount());
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,16 +1,14 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
+    url: jdbc:h2:mem:test_db;MODE=MYSQL;DATABASE_TO_LOWER=TRUE
+    username: test_user
     password:
+    driver-class-name: org.h2.Driver
 
   jpa:
-    open-in-view: true
     hibernate:
-      ddl-auto: create-drop
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+      ddl-auto: update
     show-sql: true
     properties:
-      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
-    database: h2
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## #️⃣연관된 이슈

- #58

## 📝작업 내용

- repository 테스트를 위한 데이터소스 설정을 `application-test.yml` 참조하도록 했습니다. (h2인메모리 DB, dialect는 mysql)
- 프로젝트 리스트 검색 기능을 구현했습니다.
  - 검색/조회는 REST API에서는 GET METHOD가 맞지만, 검색조건이 많기 때문에 POST METHOD를 사용합니다.
