### PR TITLE
멤버 프로필 정보 입력 불가능한 문제

### DIFF
--- a/src/main/java/com/whatpl/member/domain/Member.java
+++ b/src/main/java/com/whatpl/member/domain/Member.java
@@ -11,7 +11,6 @@ import lombok.*;
 import org.springframework.util.CollectionUtils;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -139,23 +138,11 @@ public class Member extends BaseTimeEntity {
      * memberSkills를 추가/삭제한다.
      */
     public void modifyMemberSkills(Set<Skill> skills) {
-        // skills 비어있을 경우 -> 전부 삭제
         if (CollectionUtils.isEmpty(skills)) {
-            memberSkills.clear();
-            return;
+            throw new IllegalStateException("skills cannot be empty");
         }
-
-        // member에 있던 skill이 skills에 존재하지 않는 경우 -> 삭제
-        memberSkills.stream()
-                .filter(memberSkill -> !skills.contains(memberSkill.getSkill()))
-                .forEach(removeSkill -> memberSkills.remove(removeSkill));
-
-        // member에 없던 skill이 skills에 존재하는 경우 -> 추가
-        Set<Skill> exSkills = memberSkills.stream()
-                .map(MemberSkill::getSkill)
-                .collect(Collectors.toSet());
+        memberSkills.clear();
         skills.stream()
-                .filter(skill -> !exSkills.contains(skill))
                 .map(MemberSkill::new)
                 .forEach(this::addMemberSkill);
     }
@@ -164,23 +151,11 @@ public class Member extends BaseTimeEntity {
      * memberSubjects를 추가/삭제한다.
      */
     public void modifyMemberSubject(Set<Subject> subjects) {
-        // subjects가 비어있을 경우 -> 전부 삭제
         if (CollectionUtils.isEmpty(subjects)) {
-            memberSubjects.clear();
-            return;
+            throw new IllegalStateException("subjects cannot be empty");
         }
-
-        // member에 있던 subject가 subjects에 존재하지 않는 경우 -> 삭제
-        memberSubjects.stream()
-                .filter(memberSubject -> !subjects.contains(memberSubject.getSubject()))
-                .forEach(removeSubject -> memberSubjects.remove(removeSubject));
-
-        // member에 없던 subject가 subjects에 존재하는 경우 -> 추가
-        Set<Subject> exSubjects = memberSubjects.stream()
-                .map(MemberSubject::getSubject)
-                .collect(Collectors.toSet());
+        memberSubjects.clear();
         subjects.stream()
-                .filter(subject -> !exSubjects.contains(subject))
                 .map(MemberSubject::new)
                 .forEach(this::addMemberSubject);
     }
@@ -189,23 +164,9 @@ public class Member extends BaseTimeEntity {
      * memberReferences를 추가/삭제한다.
      */
     public void modifyMemberReference(Set<String> references) {
-        // references 비어있을 경우 -> 전부 삭제
-        if (CollectionUtils.isEmpty(references)) {
-            memberReferences.clear();
-            return;
-        }
-
-        // member에 있던 reference가 references에 존재하지 않는 경우 -> 삭제
-        memberReferences.stream()
-                .filter(memberReference -> !references.contains(memberReference.getReference()))
-                .forEach(removeReference -> memberReferences.remove(removeReference));
-
-        // member에 없던 reference가 references에 존재하는 경우 -> 추가
-        Set<String> exReferences = memberReferences.stream()
-                .map(MemberReference::getReference)
-                .collect(Collectors.toSet());
-        references.stream()
-                .filter(reference -> !exReferences.contains(reference))
+        memberReferences.clear();
+        Optional.ofNullable(references)
+                .orElseGet(Collections::emptySet).stream()
                 .map(MemberReference::new)
                 .forEach(this::addMemberReference);
     }

--- a/src/main/java/com/whatpl/member/dto/ProfileOptionalRequest.java
+++ b/src/main/java/com/whatpl/member/dto/ProfileOptionalRequest.java
@@ -14,10 +14,10 @@ import java.util.Set;
 @AllArgsConstructor
 public class ProfileOptionalRequest {
 
-    @Size(max = 5, message = "관심주제는 최대 5개 입력 가능합니다.")
+    @Size(max = 5, message = "관심주제는 최대 6개 입력 가능합니다.")
     private Set<Subject> subjects;
 
-    @Size(max = 3, message = "참고링크는 최대 3개 첨부 가능합니다.")
+    @Size(max = 5, message = "참고링크는 최대 5개 첨부 가능합니다.")
     private Set<String> references;
 
     private WorkTime workTime;

--- a/src/main/java/com/whatpl/member/dto/ProfileRequiredRequest.java
+++ b/src/main/java/com/whatpl/member/dto/ProfileRequiredRequest.java
@@ -6,6 +6,7 @@ import com.whatpl.global.common.domain.enums.Skill;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +29,7 @@ public class ProfileRequiredRequest {
     private Career career;
 
     @NotNull(message = "기술스택은 필수 입력 항목입니다.")
-    @NotEmpty(message = "기술스택은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 10, message = "기술스택은 1 ~ 10개 입력 가능합니다.")
     private Set<Skill> skills;
 
     private boolean profileOpen;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #22

## 📝작업 내용

- Member 프로필 정보 수정 시 skill값이 이미 존재할 경우 수정로직 오류 발생하는 문제 수정
- 자바 Collection을 forEach메서드로 순회하면서 Collection 요소를 삭제할 경우 java.util.ConcurrentModificationException 발생

## 참고자료

[[Java] ConcurrentModificationException 원인과 해결방법](https://hbase.tistory.com/322)

![image](https://github.com/whatpl/whatpl-backend/assets/39439576/30e7bd87-379e-4803-bb5e-028f2270c6eb)