### PR TITLE
Redisson을 활용한 분산락 AOP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.apache.commons:commons-lang3:3.14.0'
+	implementation 'org.redisson:redisson:3.32.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/whatpl/global/aop/advisor/DistributedLockAspect.java
+++ b/src/main/java/com/whatpl/global/aop/advisor/DistributedLockAspect.java
@@ -1,0 +1,62 @@
+package com.whatpl.global.aop.advisor;
+
+import com.whatpl.global.aop.annotation.DistributedLock;
+import com.whatpl.global.aop.transaction.AopTransaction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.util.CastUtils;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String REDISSON_LOCK_PREFIX = "lock:";
+    private final RedissonClient redissonClient;
+    private final AopTransaction aopTransaction;
+
+    /**
+     * aopTransaction.proceed(joinPoint) - 트랜잭션이 수행된 이후 락 해제가 보장된다.
+     */
+    @Around("@annotation(com.whatpl.global.aop.annotation.DistributedLock)")
+    public Object execute(final ProceedingJoinPoint joinPoint) throws Throwable {
+        DistributedLock distributedLock = getDistributedLock(joinPoint);
+
+        String name = REDISSON_LOCK_PREFIX + distributedLock.name();
+        RLock lock = redissonClient.getLock(name);
+
+        try {
+            boolean available = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.unit());
+            if (!available) {
+                log.info("DistributedLock 획득 실패. name = {}", name);
+                return false;
+            }
+
+            return aopTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("DistributedLock 작업 쓰레드가 인터럽트 되었습니다. name = " + name, e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                try {
+                    lock.unlock();
+                } catch (IllegalMonitorStateException e) {
+                    log.error("DistributedLock 이미 해제 되었습니다. name = {}", name);
+                }
+            }
+        }
+    }
+
+    private DistributedLock getDistributedLock(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = CastUtils.cast(joinPoint.getSignature());
+        return signature.getMethod().getAnnotation(DistributedLock.class);
+    }
+}

--- a/src/main/java/com/whatpl/global/aop/annotation/DistributedLock.java
+++ b/src/main/java/com/whatpl/global/aop/annotation/DistributedLock.java
@@ -1,0 +1,37 @@
+package com.whatpl.global.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redisson 을 이용한 분산락 AOP 적용 애노테이션
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락 이름
+     */
+    String name();
+
+    /**
+     * 락 대기 시간
+     * 락 획득을 위해 waitTime 만큼 대기한다.
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다.
+     */
+    long leaseTime() default 3L;
+
+    /**
+     * 락 시간 단위
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/com/whatpl/global/aop/transaction/AopTransaction.java
+++ b/src/main/java/com/whatpl/global/aop/transaction/AopTransaction.java
@@ -1,0 +1,23 @@
+package com.whatpl.global.aop.transaction;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP 적용 시 트랜잭션 분리를 위한 클래스
+ */
+@Component
+public class AopTransaction {
+
+    /**
+     * 물리 트랜잭션을 분리
+     * 트랜잭션 어드바이스와 커스텀 어드바이스 순서에 상관 없이 커스텀 어드바이스에서 트랜잭션이 수행됨을 보장
+     * 커스텀 어드바이스에서 finally 구문 수행 시 필요 (ex. 락 해제)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/whatpl/global/config/RedissonConfig.java
+++ b/src/main/java/com/whatpl/global/config/RedissonConfig.java
@@ -1,0 +1,26 @@
+package com.whatpl.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedissonConfig {
+
+    private final RedisProperties redisProperties;
+    private static final String REDISSON_ADDRESS_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_ADDRESS_PREFIX + redisProperties.getHost() + ":" + redisProperties.getPort())
+                .setPassword(redisProperties.getPassword());
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/whatpl/global/listener/InitDataLoader.java
+++ b/src/main/java/com/whatpl/global/listener/InitDataLoader.java
@@ -1,24 +1,22 @@
 package com.whatpl.global.listener;
 
+import com.whatpl.global.aop.annotation.DistributedLock;
 import com.whatpl.global.common.domain.enums.Career;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.common.domain.enums.Skill;
 import com.whatpl.global.common.domain.enums.WorkTime;
-import com.whatpl.member.domain.*;
+import com.whatpl.member.domain.Member;
 import com.whatpl.member.domain.enums.SocialType;
 import com.whatpl.member.repository.MemberRepository;
 import jakarta.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
@@ -28,29 +26,13 @@ public class InitDataLoader implements ApplicationListener<ApplicationReadyEvent
 
     private static final AtomicLong memberCount = new AtomicLong(0L);
     private final MemberRepository memberRepository;
-    private final RedissonClient redissonClient;
 
     @Override
+    @DistributedLock(name = "app:init")
     @Transactional
     public void onApplicationEvent(@Nonnull ApplicationReadyEvent event) {
         log.info("===== Application 로딩 후 DATA 초기화 작업을 시작합니다. =====");
-        RLock lock = redissonClient.getLock("lock_application_init");
-        try {
-            boolean isLocked = lock.tryLock(10, TimeUnit.SECONDS);
-            if (!isLocked) {
-                log.info("Application 초기화 Lock 획득 실패");
-                return;
-            }
-
-            setupInitMembers();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Application 초기화 쓰레드가 인터럽트 되었습니다.");
-        } finally {
-            if(lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+        setupInitMembers();
         log.info("===== Application 로딩 후 DATA 초기화 작업을 종료합니다. =====");
     }
 

--- a/src/main/java/com/whatpl/global/listener/InitDataLoader.java
+++ b/src/main/java/com/whatpl/global/listener/InitDataLoader.java
@@ -10,12 +10,15 @@ import com.whatpl.member.repository.MemberRepository;
 import jakarta.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
@@ -25,12 +28,29 @@ public class InitDataLoader implements ApplicationListener<ApplicationReadyEvent
 
     private static final AtomicLong memberCount = new AtomicLong(0L);
     private final MemberRepository memberRepository;
+    private final RedissonClient redissonClient;
 
     @Override
     @Transactional
     public void onApplicationEvent(@Nonnull ApplicationReadyEvent event) {
         log.info("===== Application 로딩 후 DATA 초기화 작업을 시작합니다. =====");
-        setupInitMembers();
+        RLock lock = redissonClient.getLock("lock_application_init");
+        try {
+            boolean isLocked = lock.tryLock(10, TimeUnit.SECONDS);
+            if (!isLocked) {
+                log.info("Application 초기화 Lock 획득 실패");
+                return;
+            }
+
+            setupInitMembers();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Application 초기화 쓰레드가 인터럽트 되었습니다.");
+        } finally {
+            if(lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
         log.info("===== Application 로딩 후 DATA 초기화 작업을 종료합니다. =====");
     }
 

--- a/src/main/java/com/whatpl/member/repository/MemberQueryRepository.java
+++ b/src/main/java/com/whatpl/member/repository/MemberQueryRepository.java
@@ -2,8 +2,6 @@ package com.whatpl.member.repository;
 
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.domain.enums.SocialType;
-import jakarta.persistence.LockModeType;
-import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
 
@@ -11,6 +9,5 @@ public interface MemberQueryRepository {
 
     Optional<Member> findMemberWithAllById(long id);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Member> findMemberWithAllBySocialTypeId(SocialType socialType, String socialId);
 }


### PR DESCRIPTION
## 📝작업 내용

- 애플리케이션 초기화 데이터 insert하는 로직에서 애플리케이션 인스턴스가 2개 띄워져 있을 경우 데이터가 중복해서 들어가는 문제 발생
- Redisson 클라이언트 (redis pub/sub 구조) 를 활용한 분산락을 구현하여 동시성 이슈 해결
- 분산락은 다른 곳에서도 사용할 수 있도록 AOP로 구현 (포인트컷 = `@DistributedLock`)
- 분산락 AOP에서는 비즈니스 로직이 항상 커밋/롤백된 이후 LOCK을 해제할 수 있도록 구현
