### PR TITLE
프로젝트 수정

### DIFF
--- a/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
@@ -18,6 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class MethodSecurityConfig {
 
+    private final ProjectPermissionManager projectPermissionManager;
     private final ApplyPermissionManager applyPermissionManager;
     private final ProjectCommentPermissionManager projectCommentPermissionManager;
     private final ProjectLikePermissionManager projectLikePermissionManager;
@@ -27,6 +28,7 @@ public class MethodSecurityConfig {
     @Bean
     public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
         Map<String, WhatplPermissionManager> whatplPermissionEvaluatorMap = new HashMap<>();
+        whatplPermissionEvaluatorMap.put("PROJECT", projectPermissionManager);
         whatplPermissionEvaluatorMap.put("APPLY", applyPermissionManager);
         whatplPermissionEvaluatorMap.put("PROJECT_COMMENT", projectCommentPermissionManager);
         whatplPermissionEvaluatorMap.put("PROJECT_LIKE", projectLikePermissionManager);

--- a/src/main/java/com/whatpl/global/exception/ErrorCode.java
+++ b/src/main/java/com/whatpl/global/exception/ErrorCode.java
@@ -41,6 +41,8 @@ public enum ErrorCode {
     NOT_FOUND_PROJECT_PARTICIPANT("PRJ14", 404, "프로젝트 참여자를 찾을 수 없습니다."),
     NOT_MATCH_PROJECT_PARTICIPANT("PRJ15", 400, "프로젝트 ID와 참여자 ID가 일치하지 않습니다."),
     CANT_PROCESS_EXCLUDED("PRJ16", 400, "프로젝트 지원서를 제외 상태로 변경할 수 없습니다."),
+    CANT_DELETE_RECRUIT_JOB_EXISTS_PARTICIPANT("PRJ17", 400, "참여자가 존재하는 모집직군은 삭제할 수 없습니다."),
+    RECRUIT_AMOUNT_CANT_LESS_THEN_PARTICIPANT_AMOUNT("PRJ18", 400, "모집인원은 프로젝트 참여자 수보다 적을 수 없습니다."),
 
     // APPLY
     NOT_FOUND_APPLY("APL1", 404, "지원정보를 찾을 수 없습니다."),

--- a/src/main/java/com/whatpl/global/security/permission/manager/ProjectPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/ProjectPermissionManager.java
@@ -1,0 +1,38 @@
+package com.whatpl.global.security.permission.manager;
+
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectPermissionManager implements WhatplPermissionManager {
+
+    private final ProjectRepository projectRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission) {
+        return switch (permission) {
+            case "UPDATE" -> hasUpdatePrivilege(memberPrincipal, targetId);
+            default -> false;
+        };
+    }
+
+    /**
+     * 프로젝트 수정 권한
+     * 프로젝트 모집자(등록자)
+     */
+    private boolean hasUpdatePrivilege(MemberPrincipal memberPrincipal, Long projectId) {
+        Project project = projectRepository.findWithWriterById(projectId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
+        return Objects.equals(project.getWriter().getId(), memberPrincipal.getId());
+    }
+}

--- a/src/main/java/com/whatpl/project/controller/ProjectController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectController.java
@@ -5,10 +5,7 @@ import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.pagination.SliceResponse;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.project.domain.enums.ProjectStatus;
-import com.whatpl.project.dto.ProjectCreateRequest;
-import com.whatpl.project.dto.ProjectInfo;
-import com.whatpl.project.dto.ProjectReadResponse;
-import com.whatpl.project.dto.ProjectSearchCondition;
+import com.whatpl.project.dto.*;
 import com.whatpl.project.service.ProjectReadService;
 import com.whatpl.project.service.ProjectWriteService;
 import jakarta.validation.Valid;
@@ -16,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,5 +55,13 @@ public class ProjectController {
         searchCondition.assignLoginMember(principal);
         Slice<ProjectInfo> projects = projectReadService.searchProjectList(pageable, searchCondition);
         return ResponseEntity.ok(new SliceResponse<>(projects));
+    }
+
+    @PreAuthorize("hasPermission(#projectId, 'PROJECT', 'UPDATE')")
+    @PutMapping("/projects/{projectId}")
+    public ResponseEntity<Void> modify(@PathVariable Long projectId,
+                                       @Valid @RequestBody ProjectUpdateRequest request) {
+        projectWriteService.modifyProject(projectId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
@@ -57,41 +57,6 @@ public final class ProjectModelConverter {
         return project;
     }
 
-    public static Project toProject(final ProjectCreateRequest request, final Member writer) {
-        if (request == null || writer == null) {
-            throw new IllegalStateException("convert failed!");
-        }
-        Project project = Project.builder()
-                .title(request.getTitle())
-                .profitable(request.getProfitable())
-                .term(request.getTerm())
-                .status(ProjectStatus.RECRUITING)
-                .subject(request.getSubject())
-                .meetingType(request.getMeetingType())
-                .content(request.getContent())
-                .build();
-
-        // ProjectSkill 추가
-        Optional.ofNullable(request.getSkills())
-                .orElseGet(Collections::emptySet).stream()
-                .map(ProjectSkill::new)
-                .forEach(project::addProjectSkill);
-
-        // RecruitJob 추가
-        Optional.ofNullable(request.getRecruitJobs())
-                .orElseGet(Collections::emptySet).stream()
-                .map(recruitJobField -> RecruitJob.builder()
-                        .job(recruitJobField.getJob())
-                        .recruitAmount(recruitJobField.getRecruitAmount())
-                        .build())
-                .forEach(project::addRecruitJob);
-
-        // 대표이미지, 작성자 추가
-        project.addRepresentImageAndWriter(null, writer);
-
-        return project;
-    }
-
     public static ProjectReadResponse toProjectReadResponse(Project project, long likes, boolean myLike) {
         return ProjectReadResponse.builder()
                 .projectId(project.getId())

--- a/src/main/java/com/whatpl/project/domain/Project.java
+++ b/src/main/java/com/whatpl/project/domain/Project.java
@@ -172,7 +172,7 @@ public class Project extends BaseTimeEntity {
 
     /**
      * 모집직군의 모집인원을 수정합니다.
-     * 참여자 수는 모집인원보다 적을 수 없습니다.
+     * 모집인원은 프로젝트 참여자 수보다 적을 수 없습니다.
      */
     private void modifyRecruitJobAmount(Collection<RecruitJobField> recruitJobFields) {
         List<RecruitJob> modifyRecruitJobs = this.recruitJobs.stream()
@@ -181,14 +181,14 @@ public class Project extends BaseTimeEntity {
                         .anyMatch(recruitJobField -> recruitJobField.getJob().equals(recruitJob.getJob())))
                 .toList();
 
-        modifyRecruitJobs.forEach(recruitJob -> {
-            Optional.ofNullable(recruitJobFields)
-                    .orElseGet(Collections::emptyList).forEach(recruitJobField -> {
-                        if (recruitJobField.getJob().equals(recruitJob.getJob())) {
-                            recruitJob.changeRecruitAmount(recruitJobField.getRecruitAmount());
-                        }
-                    });
-        });
+        modifyRecruitJobs.forEach(recruitJob -> Optional.ofNullable(recruitJobFields)
+                .orElseGet(Collections::emptyList)
+                .forEach(recruitJobField -> {
+                    if (recruitJobField.getJob().equals(recruitJob.getJob())) {
+                        recruitJob.changeRecruitAmount(recruitJobField.getRecruitAmount());
+                    }
+                })
+        );
 
         modifyRecruitJobs.forEach(recruitJob -> {
             int participantAmount = this.projectParticipants.stream()

--- a/src/main/java/com/whatpl/project/domain/ProjectParticipant.java
+++ b/src/main/java/com/whatpl/project/domain/ProjectParticipant.java
@@ -4,10 +4,7 @@ import com.whatpl.global.common.BaseTimeEntity;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.member.domain.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Entity
@@ -22,6 +19,7 @@ public class ProjectParticipant extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Job job;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;

--- a/src/main/java/com/whatpl/project/domain/RecruitJob.java
+++ b/src/main/java/com/whatpl/project/domain/RecruitJob.java
@@ -25,8 +25,18 @@ public class RecruitJob {
     private Project project;
 
     @Builder
-    public RecruitJob(Job job, Integer recruitAmount) {
+    public RecruitJob(Job job, int recruitAmount) {
+        if(recruitAmount < 1 || recruitAmount > 5) {
+            throw new IllegalArgumentException("recruitAmount must be between 1 and 5");
+        }
         this.job = job;
+        this.recruitAmount = recruitAmount;
+    }
+
+    public void changeRecruitAmount(int recruitAmount) {
+        if(recruitAmount < 1 || recruitAmount > 5) {
+            throw new IllegalArgumentException("recruitAmount must be between 1 and 5");
+        }
         this.recruitAmount = recruitAmount;
     }
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectCreateRequest.java
@@ -1,14 +1,14 @@
 package com.whatpl.project.dto;
 
-import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.common.domain.enums.Skill;
 import com.whatpl.global.common.domain.enums.Subject;
 import com.whatpl.project.domain.enums.MeetingType;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
 
@@ -49,16 +49,4 @@ public class ProjectCreateRequest {
     private Integer term;
 
     private Long representImageId;
-
-    @Getter
-    @AllArgsConstructor
-    @EqualsAndHashCode(of = "job")
-    public static class RecruitJobField {
-        @NotNull(message = "직무는 필수 입력 항목입니다.")
-        private Job job;
-        @NotNull(message = "모집인원은 필수 입력 항목입니다.")
-        @Min(value = 1, message = "모집인원은 최소 1명 이상 입력 가능합니다.")
-        @Max(value = 5, message = "모집인원은 최소 5명 이하 입력 가능합니다.")
-        private Integer recruitAmount;
-    }
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectCreateRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
 
@@ -27,9 +28,11 @@ public class ProjectCreateRequest {
 
     @Valid
     @NotNull(message = "모집직군은 필수 입력 항목입니다.")
+    @Size(min = 1, message = "모집직군은 1개 이상 입력 가능합니다. ")
     private Set<RecruitJobField> recruitJobs;
 
     @NotNull(message = "기술 스택은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 15, message = "기술스택은 1 ~ 15까지 입력 가능합니다.")
     private Set<Skill> skills;
 
     @NotBlank(message = "프로젝트 설명은 필수 입력 항목입니다.")
@@ -49,12 +52,13 @@ public class ProjectCreateRequest {
 
     @Getter
     @AllArgsConstructor
+    @EqualsAndHashCode(of = "job")
     public static class RecruitJobField {
         @NotNull(message = "직무는 필수 입력 항목입니다.")
         private Job job;
         @NotNull(message = "모집인원은 필수 입력 항목입니다.")
         @Min(value = 1, message = "모집인원은 최소 1명 이상 입력 가능합니다.")
-        @Max(value = 10, message = "모집인원은 최소 10명 이하 입력 가능합니다.")
+        @Max(value = 5, message = "모집인원은 최소 5명 이하 입력 가능합니다.")
         private Integer recruitAmount;
     }
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectUpdateRequest.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectUpdateRequest.java
@@ -1,0 +1,52 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Skill;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.project.domain.enums.MeetingType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProjectUpdateRequest {
+
+    @NotBlank(message = "제목은 필수 입력 항목입니다.")
+    @Size(max = 30, message = "제목은 최대 30자까지 입력 가능합니다.")
+    private String title;
+
+    @NotNull(message = "프로젝트의 도메인은 필수 입력 항목입니다.")
+    private Subject subject;
+
+    @Valid
+    @NotNull(message = "모집직군은 필수 입력 항목입니다.")
+    @Size(min = 1, message = "모집직군은 1개 이상 입력 가능합니다. ")
+    private Set<RecruitJobField> recruitJobs;
+
+    @NotNull(message = "기술 스택은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 15, message = "기술스택은 1 ~ 15까지 입력 가능합니다.")
+    private Set<Skill> skills;
+
+    @NotBlank(message = "프로젝트 설명은 필수 입력 항목입니다.")
+    private String content;
+
+    @NotNull(message = "수익화 여부는 필수 입력 항목입니다.")
+    private Boolean profitable;
+
+    @NotNull(message = "모임 방식은 필수 입력 항목입니다.")
+    private MeetingType meetingType;
+
+    @NotNull(message = "기간은 필수 입력 항목입니다.")
+    @Range(min = 1, max = 30, message = "기간은 1 ~ 30까지 입력 가능합니다.")
+    private Integer term;
+
+    private Long representImageId;
+}

--- a/src/main/java/com/whatpl/project/dto/RecruitJobField.java
+++ b/src/main/java/com/whatpl/project/dto/RecruitJobField.java
@@ -16,6 +16,6 @@ public class RecruitJobField {
     private Job job;
     @NotNull(message = "모집인원은 필수 입력 항목입니다.")
     @Min(value = 1, message = "모집인원은 최소 1명 이상 입력 가능합니다.")
-    @Max(value = 5, message = "모집인원은 최소 5명 이하 입력 가능합니다.")
+    @Max(value = 5, message = "모집인원은 최대 5명 이하 입력 가능합니다.")
     private Integer recruitAmount;
 }

--- a/src/main/java/com/whatpl/project/dto/RecruitJobField.java
+++ b/src/main/java/com/whatpl/project/dto/RecruitJobField.java
@@ -1,0 +1,21 @@
+package com.whatpl.project.dto;
+
+import com.whatpl.global.common.domain.enums.Job;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode(of = "job")
+public class RecruitJobField {
+    @NotNull(message = "직무는 필수 입력 항목입니다.")
+    private Job job;
+    @NotNull(message = "모집인원은 필수 입력 항목입니다.")
+    @Min(value = 1, message = "모집인원은 최소 1명 이상 입력 가능합니다.")
+    @Max(value = 5, message = "모집인원은 최소 5명 이하 입력 가능합니다.")
+    private Integer recruitAmount;
+}

--- a/src/main/java/com/whatpl/project/service/ProjectApplyService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectApplyService.java
@@ -1,6 +1,7 @@
 package com.whatpl.project.service;
 
 import com.whatpl.chat.service.ChatService;
+import com.whatpl.global.aop.annotation.DistributedLock;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
@@ -63,6 +64,7 @@ public class ProjectApplyService {
     }
 
     @Transactional
+    @DistributedLock(name = "project:modify")
     public void status(final long projectId, final long applyId, final ApplyStatus applyStatus) {
         Project project = projectRepository.findWithRecruitJobsById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/whatpl/project/service/ProjectWriteService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectWriteService.java
@@ -28,18 +28,21 @@ public class ProjectWriteService {
         Member writer = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
 
-        Project project;
-        if (request.getRepresentImageId() != null) {
-            Attachment representImage = attachmentRepository.findById(request.getRepresentImageId())
-                    .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_FILE));
-            // 프로젝트 대표이미지는 이미지 파일만 가능 (web validation 단계에서 image, pdf 가 넘어오기 때문에 한번 더 체크)
-            FileUtils.validateImageFile(representImage.getMimeType());
-            project = ProjectModelConverter.toProject(request, writer, representImage);
-        } else {
-            project = ProjectModelConverter.toProject(request, writer);
-        }
+        Attachment representImage = getRepresentImage(request.getRepresentImageId());
+        Project project = ProjectModelConverter.toProject(request, writer, representImage);
 
         Project savedProject = projectRepository.save(project);
         return savedProject.getId();
+    }
+
+    private Attachment getRepresentImage(final Long representImageId) {
+        if (representImageId == null) {
+            return null;
+        }
+        Attachment representImage = attachmentRepository.findById(representImageId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_FILE));
+        // 프로젝트 대표이미지는 이미지 파일만 가능 (web validation 단계에서 image, pdf 가 넘어오기 때문에 한번 더 체크)
+        FileUtils.validateImageFile(representImage.getMimeType());
+        return representImage;
     }
 }

--- a/src/test/java/com/whatpl/project/model/ProjectCreateRequestFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectCreateRequestFixture.java
@@ -5,6 +5,7 @@ import com.whatpl.global.common.domain.enums.Skill;
 import com.whatpl.global.common.domain.enums.Subject;
 import com.whatpl.project.domain.enums.MeetingType;
 import com.whatpl.project.dto.ProjectCreateRequest;
+import com.whatpl.project.dto.RecruitJobField;
 
 import java.util.Set;
 
@@ -18,9 +19,9 @@ public class ProjectCreateRequestFixture {
                 .title("테스트 타이틀")
                 .subject(Subject.SOCIAL_MEDIA)
                 .recruitJobs(Set.of(
-                        new ProjectCreateRequest.RecruitJobField(Job.BACKEND_DEVELOPER, 5),
-                        new ProjectCreateRequest.RecruitJobField(Job.DESIGNER, 3),
-                        new ProjectCreateRequest.RecruitJobField(Job.FRONTEND_DEVELOPER, 1)
+                        new RecruitJobField(Job.BACKEND_DEVELOPER, 5),
+                        new RecruitJobField(Job.DESIGNER, 3),
+                        new RecruitJobField(Job.FRONTEND_DEVELOPER, 1)
                 ))
                 .skills(Set.of(Skill.JAVA, Skill.FIGMA, Skill.PYTHON))
                 .content("<p>테스트 콘텐츠 HTML<p>")

--- a/src/test/java/com/whatpl/project/model/ProjectFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectFixture.java
@@ -2,8 +2,11 @@ package com.whatpl.project.model;
 
 import com.whatpl.global.common.domain.enums.Subject;
 import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.ProjectParticipant;
 import com.whatpl.project.domain.RecruitJob;
 import com.whatpl.project.domain.enums.MeetingType;
+
+import java.util.List;
 
 public class ProjectFixture {
 
@@ -25,6 +28,13 @@ public class ProjectFixture {
                 project.addRecruitJob(recruitJob);
             }
         }
+        return project;
+    }
+
+    public static Project withRecruitJobAndParticipant(List<RecruitJob> recruitJobs, List<ProjectParticipant> participant) {
+        Project project = create();
+        recruitJobs.forEach(project::addRecruitJob);
+        participant.forEach(project::addProjectParticipant);
         return project;
     }
 }

--- a/src/test/java/com/whatpl/project/model/ProjectParticipantFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectParticipantFixture.java
@@ -1,0 +1,15 @@
+package com.whatpl.project.model;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.member.domain.Member;
+import com.whatpl.project.domain.ProjectParticipant;
+
+public class ProjectParticipantFixture {
+
+    public static ProjectParticipant create(Job job, Member participant) {
+        return ProjectParticipant.builder()
+                .job(job)
+                .participant(participant)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/project/model/ProjectUpdateRequestFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectUpdateRequestFixture.java
@@ -1,0 +1,33 @@
+package com.whatpl.project.model;
+
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.common.domain.enums.Skill;
+import com.whatpl.global.common.domain.enums.Subject;
+import com.whatpl.project.domain.enums.MeetingType;
+import com.whatpl.project.dto.ProjectUpdateRequest;
+import com.whatpl.project.dto.RecruitJobField;
+
+import java.util.Set;
+
+public class ProjectUpdateRequestFixture {
+
+    private ProjectUpdateRequestFixture() {
+    }
+
+    public static ProjectUpdateRequest create() {
+        return ProjectUpdateRequest.builder()
+                .title("수정 타이틀")
+                .subject(Subject.EDUCATION)
+                .recruitJobs(Set.of(
+                        new RecruitJobField(Job.BACKEND_DEVELOPER, 5),
+                        new RecruitJobField(Job.DESIGNER, 5)
+                ))
+                .skills(Set.of(Skill.JAVA, Skill.PYTHON))
+                .content("<p>수정 콘텐츠 HTML<p>")
+                .profitable(false)
+                .meetingType(MeetingType.OFFLINE)
+                .term(5)
+                .representImageId(2L)
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/project/model/RecruitJobFixture.java
+++ b/src/test/java/com/whatpl/project/model/RecruitJobFixture.java
@@ -8,7 +8,14 @@ public class RecruitJobFixture {
     public static RecruitJob create(Job job) {
         return RecruitJob.builder()
                 .job(job)
-                .recruitAmount(10)
+                .recruitAmount(5)
+                .build();
+    }
+
+    public static RecruitJob withRecruitAmount(Job job, int recruitAmount) {
+        return RecruitJob.builder()
+                .job(job)
+                .recruitAmount(recruitAmount)
                 .build();
     }
 }

--- a/src/test/java/com/whatpl/project/service/ProjectWriteServiceTest.java
+++ b/src/test/java/com/whatpl/project/service/ProjectWriteServiceTest.java
@@ -2,12 +2,22 @@ package com.whatpl.project.service;
 
 import com.whatpl.attachment.domain.Attachment;
 import com.whatpl.attachment.repository.AttachmentRepository;
+import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.member.model.MemberFixture;
 import com.whatpl.member.repository.MemberRepository;
+import com.whatpl.project.domain.Project;
+import com.whatpl.project.domain.ProjectParticipant;
+import com.whatpl.project.domain.RecruitJob;
 import com.whatpl.project.dto.ProjectCreateRequest;
+import com.whatpl.project.dto.ProjectUpdateRequest;
+import com.whatpl.project.dto.RecruitJobField;
 import com.whatpl.project.model.ProjectCreateRequestFixture;
+import com.whatpl.project.model.ProjectFixture;
+import com.whatpl.project.model.ProjectParticipantFixture;
+import com.whatpl.project.model.RecruitJobFixture;
+import com.whatpl.project.repository.ProjectRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +26,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,6 +47,9 @@ class ProjectWriteServiceTest {
     @Mock
     AttachmentRepository attachmentRepository;
 
+    @Mock
+    ProjectRepository projectRepository;
+
     @Test
     @DisplayName("프로젝트 등록 시 대표 이미지가 이미지 타입이 아니면 실패")
     void createProject_not_image() {
@@ -50,5 +65,103 @@ class ProjectWriteServiceTest {
         BizException bizException = assertThrows(BizException.class, () ->
                 projectWriteService.createProject(projectCreateRequest, anyLong()));
         assertEquals(ErrorCode.NOT_IMAGE_FILE, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여자가 존재하는 모집직군은 삭제 불가능")
+    void cant_delete_recruit_job_exists_participant() {
+        // given
+        List<RecruitJob> recruitJobs = List.of(RecruitJobFixture.create(Job.BACKEND_DEVELOPER));
+        List<ProjectParticipant> participants = List.of(ProjectParticipantFixture.create(Job.BACKEND_DEVELOPER, MemberFixture.onlyRequired()));
+        Project project = ProjectFixture.withRecruitJobAndParticipant(recruitJobs, participants);
+        when(projectRepository.findWithRecruitJobsById(anyLong()))
+                .thenReturn(Optional.of(project));
+        ProjectUpdateRequest request = ProjectUpdateRequest.builder().build(); // 모집직군 없는 요청
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectWriteService.modifyProject(anyLong(), request));
+        assertEquals(ErrorCode.CANT_DELETE_RECRUIT_JOB_EXISTS_PARTICIPANT, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("모집인원이 참여자 수보다 적을 경우 에러")
+    void recruit_amount_cant_less_then_participant_amount() {
+        // given
+        List<RecruitJob> recruitJobs = List.of(RecruitJobFixture.create(Job.BACKEND_DEVELOPER));
+        List<ProjectParticipant> participants = List.of(
+                ProjectParticipantFixture.create(Job.BACKEND_DEVELOPER, MemberFixture.onlyRequired()),
+                ProjectParticipantFixture.create(Job.BACKEND_DEVELOPER, MemberFixture.onlyRequired())
+        );
+        Project project = ProjectFixture.withRecruitJobAndParticipant(recruitJobs, participants);
+        when(projectRepository.findWithRecruitJobsById(anyLong()))
+                .thenReturn(Optional.of(project));
+        ProjectUpdateRequest request = ProjectUpdateRequest.builder()
+                .recruitJobs(Set.of(new RecruitJobField(Job.BACKEND_DEVELOPER, 1))) // 참여자 수보다 적은 모집인원 요청
+                .build();
+
+        // when & then
+        BizException bizException = assertThrows(BizException.class, () ->
+                projectWriteService.modifyProject(anyLong(), request));
+        assertEquals(ErrorCode.RECRUIT_AMOUNT_CANT_LESS_THEN_PARTICIPANT_AMOUNT, bizException.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("기존에 존재하지 않던 모집직군 추가")
+    void merge_recruit_jobs() {
+        // given
+        Project project = ProjectFixture.withRecruitJobs(RecruitJobFixture.create(Job.BACKEND_DEVELOPER));
+        when(projectRepository.findWithRecruitJobsById(anyLong()))
+                .thenReturn(Optional.of(project));
+        ProjectUpdateRequest request = ProjectUpdateRequest.builder()
+                .recruitJobs(Set.of(
+                        new RecruitJobField(Job.BACKEND_DEVELOPER, 1),
+                        new RecruitJobField(Job.FRONTEND_DEVELOPER, 1))) // 기존에 존재하지 않던 모집직군 추가 요청
+                .build();
+
+        // when
+        projectWriteService.modifyProject(anyLong(), request);
+
+        // then
+        assertEquals(project.getRecruitJobs().size(), 2);
+    }
+
+    @Test
+    @DisplayName("기존에 존재하던 모집직군 삭제")
+    void delete_recruit_jobs() {
+        // given
+        Project project = ProjectFixture.withRecruitJobs(
+                RecruitJobFixture.create(Job.BACKEND_DEVELOPER),
+                RecruitJobFixture.create(Job.FRONTEND_DEVELOPER));
+        when(projectRepository.findWithRecruitJobsById(anyLong()))
+                .thenReturn(Optional.of(project));
+        ProjectUpdateRequest request = ProjectUpdateRequest.builder()
+                .recruitJobs(Set.of(new RecruitJobField(Job.BACKEND_DEVELOPER, 1))) // 기존에 존재하던 모집직군 삭제 요청
+                .build();
+
+        // when
+        projectWriteService.modifyProject(anyLong(), request);
+
+        // then
+        assertEquals(project.getRecruitJobs().size(), 1);
+    }
+
+    @Test
+    @DisplayName("기존에 존재하던 모집직군 인원 수정")
+    void modify_recruit_job_amount() {
+        // given
+        int modifyAmount = 1;
+        Project project = ProjectFixture.withRecruitJobs(RecruitJobFixture.withRecruitAmount(Job.BACKEND_DEVELOPER, 5));
+        when(projectRepository.findWithRecruitJobsById(anyLong()))
+                .thenReturn(Optional.of(project));
+        ProjectUpdateRequest request = ProjectUpdateRequest.builder()
+                .recruitJobs(Set.of(new RecruitJobField(Job.BACKEND_DEVELOPER, modifyAmount))) // 기존에 존재하던 모집직군의 인원 수정 요청
+                .build();
+
+        // when
+        projectWriteService.modifyProject(anyLong(), request);
+
+        // then
+        assertEquals(project.getRecruitJobs().get(0).getRecruitAmount(), modifyAmount);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #72

## 📝작업 내용

- refactor. 프로젝트 등록로직의 가독성을 개선했습니다. 기존에 if~else로 indent가 늘어나는 구조를 개선하였고, 대표이미지 존재여부에 따라 비슷한 기능의 메서드를 오버로딩 했었는데, 오버로딩하지 않고 하나의 메서드에서 대표이미지 존재여부와 상관없이 기능이 동작하도록 개선하였습니다.
- 프로젝트를 수정하는 기능을 구현했습니다.
  - 프로젝트와 1:N 연관 관계가 있는 기술 스택은 모두 DELETE 후 요청값 모두 INSERT하게 구현했습니다.
  - 프로젝트와 1:N 연관 관계가 있는 모집직군은 프로젝트 참여자, 프로젝트 지원과 연관성이 있어 모두 DELETE할 수 없었습니다. 참여자가 1명이라도 존재하는 모집직군은 삭제할 수 없고, 모집인원을 축소하는 요청일 경우 참여자 수보다 적게 수정할 수 없도록 유효성 검증하였습니다. 기존에 존재하지 않던 모집직군 요청이면 추가를, 기존에 존재하던 모집직군이 요청에 없을 경우 삭제하도록 구현했습니다. 만약, 기존에 존재하던 모집직군이면서 요청에도 존재할 경우 모집 인원을 수정합니다.