### PR TITLE
프로젝트 대표 이미지 필수 아니도록 변경

### DIFF
--- a/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
+++ b/src/main/java/com/whatpl/project/converter/ProjectModelConverter.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 public final class ProjectModelConverter {
 
     public static Project toProject(final ProjectCreateRequest request, final Member writer, final Attachment representImage) {
-        if (request == null || writer == null || representImage == null) {
+        if (request == null || writer == null) {
             throw new IllegalStateException("convert failed!");
         }
         Project project = Project.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

- #29

## 📝작업 내용

- 프로젝트 등록 시 대표이미지를 필수가 아니도록 수정했습니다.