### PR TITLE
채팅방 리스트 조회

### DIFF
--- a/src/main/java/com/whatpl/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/whatpl/chat/controller/ChatMessageController.java
@@ -2,7 +2,7 @@ package com.whatpl.chat.controller;
 
 import com.whatpl.chat.dto.ChatMessageCreateRequest;
 import com.whatpl.chat.dto.ChatMessageDto;
-import com.whatpl.chat.service.ChatService;
+import com.whatpl.chat.service.ChatMessageService;
 import com.whatpl.global.pagination.SliceResponse;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import jakarta.validation.Valid;
@@ -16,16 +16,16 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class ChatController {
+public class ChatMessageController {
 
-    private final ChatService chatService;
+    private final ChatMessageService chatMessageService;
 
     @PreAuthorize("hasPermission(#chatRoomId, 'CHAT_MESSAGE', 'CREATE')")
     @PostMapping("/chat/rooms/{chatRoomId}/messages")
     public ResponseEntity<Void> writeMessage(@PathVariable long chatRoomId,
                                              @Valid @RequestBody ChatMessageCreateRequest request,
                                              @AuthenticationPrincipal MemberPrincipal principal) {
-        chatService.sendMessage(chatRoomId, principal.getId(), request.getContent());
+        chatMessageService.sendMessage(chatRoomId, principal.getId(), request.getContent());
         return ResponseEntity.noContent().build();
     }
 
@@ -34,7 +34,7 @@ public class ChatController {
     public ResponseEntity<SliceResponse<ChatMessageDto>> readMessageList(@PathVariable long chatRoomId,
                                                                          Pageable pageable,
                                                                          @AuthenticationPrincipal MemberPrincipal principal) {
-        Slice<ChatMessageDto> chatMessageSlice = chatService.readMessages(chatRoomId, pageable, principal.getId());
+        Slice<ChatMessageDto> chatMessageSlice = chatMessageService.readMessages(chatRoomId, pageable, principal.getId());
         return ResponseEntity.ok(new SliceResponse<>(chatMessageSlice));
     }
 }

--- a/src/main/java/com/whatpl/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/whatpl/chat/controller/ChatRoomController.java
@@ -1,0 +1,27 @@
+package com.whatpl.chat.controller;
+
+import com.whatpl.chat.dto.ChatRoomResponse;
+import com.whatpl.chat.service.ChatRoomService;
+import com.whatpl.global.pagination.SliceResponse;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/chat/rooms")
+    public ResponseEntity<SliceResponse<ChatRoomResponse>> readList(Pageable pageable,
+                                                                    @AuthenticationPrincipal MemberPrincipal principal) {
+        Slice<ChatRoomResponse> chatRoomSlice = chatRoomService.readChatRooms(pageable, principal.getId());
+        return ResponseEntity.ok(new SliceResponse<>(chatRoomSlice));
+    }
+}

--- a/src/main/java/com/whatpl/chat/domain/ChatRoom.java
+++ b/src/main/java/com/whatpl/chat/domain/ChatRoom.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @Entity
 @Table(name = "chat_room")
@@ -20,6 +22,9 @@ public class ChatRoom extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "apply_id")
     private Apply apply;
+
+    @OneToMany(mappedBy = "chatRoom")
+    private List<ChatMessage> messages;
 
     public ChatRoom(Apply apply) {
         this.apply = apply;

--- a/src/main/java/com/whatpl/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/whatpl/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,28 @@
+package com.whatpl.chat.dto;
+
+import com.whatpl.global.pagination.SliceElement;
+import com.whatpl.project.domain.enums.ApplyType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomResponse implements SliceElement {
+
+    private long chatRoomId;
+    private ApplyType applyType;
+    private long projectId;
+    private String projectTitle;
+    private long opponentId;
+    private String opponentNickname;
+    private String opponentProfileImgUri; // TODO 상대방 프로필 이미지 URI
+    private String lastMessageContent;
+    private LocalDateTime lastMessageTime;
+    private boolean lastMessageRead;
+}

--- a/src/main/java/com/whatpl/chat/repository/ChatRoomQueryRepository.java
+++ b/src/main/java/com/whatpl/chat/repository/ChatRoomQueryRepository.java
@@ -1,9 +1,13 @@
 package com.whatpl.chat.repository;
 
 import com.whatpl.chat.domain.ChatRoom;
+import com.whatpl.chat.dto.ChatRoomResponse;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomQueryRepository {
     Optional<ChatRoom> findChatRoomWithAllById(Long id);
+    List<ChatRoomResponse> findChatRooms(Pageable pageable, Long memberId);
 }

--- a/src/main/java/com/whatpl/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -1,13 +1,27 @@
 package com.whatpl.chat.repository;
 
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.whatpl.chat.domain.ChatRoom;
+import com.whatpl.chat.domain.QChatMessage;
 import com.whatpl.chat.domain.QChatRoom;
+import com.whatpl.chat.dto.ChatRoomResponse;
 import com.whatpl.member.domain.QMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
+import static com.querydsl.core.types.Projections.fields;
+import static com.querydsl.jpa.JPAExpressions.select;
+import static com.whatpl.chat.domain.QChatMessage.chatMessage;
+import static com.whatpl.chat.domain.QChatRoom.chatRoom;
 import static com.whatpl.project.domain.QApply.apply;
 import static com.whatpl.project.domain.QProject.project;
 
@@ -25,7 +39,72 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
                 .leftJoin(apply.project, project).fetchJoin()
                 .leftJoin(project.writer, writer).fetchJoin()
                 .leftJoin(apply.applicant, applicant).fetchJoin()
+                .where(QChatRoom.chatRoom.id.eq(id))
                 .fetchOne();
         return Optional.ofNullable(chatRoom);
+    }
+
+    @Override
+    public List<ChatRoomResponse> findChatRooms(Pageable pageable, Long memberId) {
+        QMember writer = new QMember("writer");
+        QMember applicant = new QMember("applicant");
+
+        return queryFactory.select(fields(ChatRoomResponse.class,
+                        chatRoom.id.as("chatRoomId"),
+                        apply.type.as("applyType"),
+                        project.id.as("projectId"),
+                        project.title.as("projectTitle"),
+                        getOpponentId(memberId).as("opponentId"),
+                        getOpponentNickname(memberId).as("opponentNickname"),
+                        chatMessage.createdAt.max().as("lastMessageTime"),
+                        ExpressionUtils.as(getLastMessageContent(), "lastMessageContent"),
+                        getLastMessageRead(memberId).as("lastMessageRead")
+                ))
+                .from(chatRoom)
+                .leftJoin(chatRoom.apply, apply)
+                .leftJoin(apply.project, project)
+                .leftJoin(project.writer, writer)
+                .leftJoin(apply.applicant, applicant)
+                .leftJoin(chatRoom.messages, chatMessage)
+                .where(apply.applicant.id.eq(memberId)
+                        .or(project.writer.id.eq(memberId)))
+                .groupBy(chatRoom.id)
+                .orderBy(chatMessage.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+    }
+
+    private NumberExpression<Long> getOpponentId(Long memberId) {
+        return new CaseBuilder()
+                .when(apply.applicant.id.eq(memberId))
+                .then(project.writer.id)
+                .otherwise(apply.applicant.id);
+    }
+
+    private StringExpression getOpponentNickname(Long memberId) {
+        return new CaseBuilder()
+                .when(apply.applicant.id.eq(memberId))
+                .then(project.writer.nickname)
+                .otherwise(apply.applicant.nickname);
+    }
+
+    private JPQLQuery<String> getLastMessageContent() {
+        QChatMessage scalaChatMessage = new QChatMessage("scalaChatMessage");
+        return select(scalaChatMessage.content)
+                .from(scalaChatMessage)
+                .where(scalaChatMessage.id.eq(chatMessage.id.max()));
+    }
+
+    private BooleanExpression getLastMessageRead(Long memberId) {
+        QChatMessage scalaChatMessage = new QChatMessage("scalaChatMessage");
+        return new CaseBuilder()
+                .when(select(scalaChatMessage.sender.id)
+                        .from(scalaChatMessage)
+                        .where(scalaChatMessage.id.eq(chatMessage.id.max())).eq(memberId))
+                .then(true)
+                .otherwise(select(scalaChatMessage.readAt)
+                        .from(scalaChatMessage)
+                        .where(scalaChatMessage.id.eq(chatMessage.id.max())).isNotNull());
     }
 }

--- a/src/main/java/com/whatpl/chat/service/ChatMessageService.java
+++ b/src/main/java/com/whatpl/chat/service/ChatMessageService.java
@@ -9,8 +9,6 @@ import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.repository.MemberRepository;
-import com.whatpl.project.domain.Apply;
-import com.whatpl.project.domain.enums.ApplyType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,23 +19,11 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class ChatService {
+public class ChatMessageService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final MemberRepository memberRepository;
-
-    @Transactional
-    public long createChatRoom(final Apply apply, final String content) {
-        ChatRoom chatRoom = ChatRoom.from(apply);
-        chatRoomRepository.save(chatRoom);
-        // 메시지 발신자 = 프로젝트 지원일 경우 지원자 : 프로젝트 참여 제안일 경우 모집자
-        long senderId = apply.getType() == ApplyType.APPLY ?
-                apply.getApplicant().getId() : apply.getProject().getWriter().getId();
-        this.sendMessage(chatRoom.getId(), senderId, content);
-
-        return chatRoom.getId();
-    }
 
     @Transactional
     public void sendMessage(final Long chatRoomId, final Long senderId, final String content) {

--- a/src/main/java/com/whatpl/chat/service/ChatRoomService.java
+++ b/src/main/java/com/whatpl/chat/service/ChatRoomService.java
@@ -1,0 +1,42 @@
+package com.whatpl.chat.service;
+
+import com.whatpl.chat.domain.ChatRoom;
+import com.whatpl.chat.dto.ChatRoomResponse;
+import com.whatpl.chat.repository.ChatRoomRepository;
+import com.whatpl.global.util.PaginationUtils;
+import com.whatpl.project.domain.Apply;
+import com.whatpl.project.domain.enums.ApplyType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageService chatMessageService;
+
+    @Transactional
+    public long createChatRoom(final Apply apply, final String content) {
+        ChatRoom chatRoom = ChatRoom.from(apply);
+        chatRoomRepository.save(chatRoom);
+        // 메시지 발신자 = 프로젝트 지원일 경우 지원자 : 프로젝트 참여 제안일 경우 모집자
+        long senderId = apply.getType() == ApplyType.APPLY ?
+                apply.getApplicant().getId() : apply.getProject().getWriter().getId();
+        chatMessageService.sendMessage(chatRoom.getId(), senderId, content);
+
+        return chatRoom.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ChatRoomResponse> readChatRooms(final Pageable pageable, final Long memberId) {
+        List<ChatRoomResponse> chatRooms = chatRoomRepository.findChatRooms(pageable, memberId);
+        return new SliceImpl<>(chatRooms, pageable, PaginationUtils.hasNext(chatRooms, pageable.getPageSize()));
+    }
+}

--- a/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
@@ -62,7 +62,7 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
                         project.subject.as("subject"),
                         project.profitable.as("profitable"),
                         project.views.as("vies"),
-                        buildRepresentImageUri(),
+                        buildRepresentImageUri().as("representImageUri"),
                         myLikeExists(searchCondition).as("myLike")
                 ))
                 .from(project)
@@ -149,7 +149,7 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
         return new CaseBuilder()
                 .when(project.representImage.isNull())
                 .then("/images/default?type=project")
-                .otherwise(project.representImage.id.stringValue().prepend("/attachments/").concat("/images")).as("representImageUri");
+                .otherwise(project.representImage.id.stringValue().prepend("/attachments/").concat("/images"));
     }
 
     private List<Long> toProjectIds(List<ProjectInfo> projectInfos) {

--- a/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/project/repository/ProjectQueryRepositoryImpl.java
@@ -152,12 +152,6 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
                 .otherwise(project.representImage.id.stringValue().prepend("/attachments/").concat("/images"));
     }
 
-    private List<Long> toProjectIds(List<ProjectInfo> projectInfos) {
-        return projectInfos.stream()
-                .map(ProjectInfo::getProjectId)
-                .toList();
-    }
-
     private BooleanExpression subjectEq(Subject subject) {
         return subject != null ? project.subject.eq(subject) : null;
     }

--- a/src/main/java/com/whatpl/project/service/ProjectApplyService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectApplyService.java
@@ -1,7 +1,8 @@
 package com.whatpl.project.service;
 
-import com.whatpl.chat.service.ChatService;
+import com.whatpl.chat.service.ChatRoomService;
 import com.whatpl.global.aop.annotation.DistributedLock;
+import com.whatpl.global.common.domain.enums.ApplyStatus;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
@@ -11,7 +12,6 @@ import com.whatpl.project.domain.Apply;
 import com.whatpl.project.domain.Project;
 import com.whatpl.project.domain.ProjectParticipant;
 import com.whatpl.project.domain.RecruitJob;
-import com.whatpl.global.common.domain.enums.ApplyStatus;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.dto.ApplyResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
@@ -30,7 +30,7 @@ public class ProjectApplyService {
     private final ProjectRepository projectRepository;
     private final ApplyRepository applyRepository;
     private final ProjectParticipantRepository projectParticipantRepository;
-    private final ChatService chatService;
+    private final ChatRoomService chatRoomService;
 
     @Transactional
     public ApplyResponse apply(final ProjectApplyRequest request, final long projectId, final long applicantId) {
@@ -54,7 +54,7 @@ public class ProjectApplyService {
         Apply savedApply = applyRepository.save(apply);
 
         // 지원 쪽지 발송
-        long chatRoomId = chatService.createChatRoom(apply, request.getContent());
+        long chatRoomId = chatRoomService.createChatRoom(apply, request.getContent());
 
         return ApplyResponse.builder()
                 .applyId(savedApply.getId())

--- a/src/test/java/com/whatpl/ApiDocTag.java
+++ b/src/test/java/com/whatpl/ApiDocTag.java
@@ -15,7 +15,8 @@ public enum ApiDocTag {
     PROJECT_APPLY("Project Apply"),
     PROJECT_PARTICIPANT("Project Participants"),
     ATTACHMENT("Attachments"),
-    CHAT("Chats"),
+    CHAT_ROOM("Chat Rooms"),
+    CHAT_MESSAGE("Chat Messages"),
     DOMAIN("Domains"),
     IMAGE("Images");
 

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -2,7 +2,8 @@ package com.whatpl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whatpl.attachment.service.AttachmentService;
-import com.whatpl.chat.service.ChatService;
+import com.whatpl.chat.service.ChatMessageService;
+import com.whatpl.chat.service.ChatRoomService;
 import com.whatpl.global.config.SecurityConfig;
 import com.whatpl.global.image.ImageProperties;
 import com.whatpl.global.jwt.JwtProperties;
@@ -70,7 +71,10 @@ public abstract class BaseSecurityWebMvcTest {
     protected ProjectLikeService projectLikeService;
 
     @MockBean
-    protected ChatService chatService;
+    protected ChatRoomService chatRoomService;
+
+    @MockBean
+    protected ChatMessageService chatMessageService;
 
     @MockBean
     protected ProjectParticipantService projectParticipantService;

--- a/src/test/java/com/whatpl/chat/controller/ChatMessageControllerTest.java
+++ b/src/test/java/com/whatpl/chat/controller/ChatMessageControllerTest.java
@@ -37,14 +37,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-class ChatControllerTest extends BaseSecurityWebMvcTest {
+class ChatMessageControllerTest extends BaseSecurityWebMvcTest {
 
     @Test
     @WithMockWhatplMember
     @DisplayName("메시지 발송 API Docs")
     void writeMessage() throws Exception {
         // given
-        doNothing().when(chatService).sendMessage(anyLong(), anyLong(), anyString());
+        doNothing().when(chatMessageService).sendMessage(anyLong(), anyLong(), anyString());
         ChatMessageCreateRequest request = ChatMessageCreateRequest.builder()
                 .content("메시지 내용")
                 .build();
@@ -102,7 +102,7 @@ class ChatControllerTest extends BaseSecurityWebMvcTest {
                         ZoneId.of("Asia/Seoul"))))
                 .build();
         SliceImpl<ChatMessageDto> chatMessageSlice = new SliceImpl<>(List.of(chatMessageDto));
-        when(chatService.readMessages(anyLong(), any(Pageable.class), anyLong()))
+        when(chatMessageService.readMessages(anyLong(), any(Pageable.class), anyLong()))
                 .thenReturn(chatMessageSlice);
 
         // expected

--- a/src/test/java/com/whatpl/chat/controller/ChatMessageControllerTest.java
+++ b/src/test/java/com/whatpl/chat/controller/ChatMessageControllerTest.java
@@ -60,7 +60,7 @@ class ChatMessageControllerTest extends BaseSecurityWebMvcTest {
                 )
                 .andDo(print())
                 .andDo(document("send-message",
-                        resourceDetails().tag(ApiDocTag.CHAT.getTag())
+                        resourceDetails().tag(ApiDocTag.CHAT_MESSAGE.getTag())
                                 .summary("메시지 발송")
                                 .description("""
                                         메시지를 발송합니다.
@@ -128,7 +128,7 @@ class ChatMessageControllerTest extends BaseSecurityWebMvcTest {
                 )
                 .andDo(print())
                 .andDo(document("read-message-list",
-                        resourceDetails().tag(ApiDocTag.CHAT.getTag())
+                        resourceDetails().tag(ApiDocTag.CHAT_MESSAGE.getTag())
                                 .summary("메시지 리스트 조회")
                                 .description("""
                                         메시지 리스트를 조회합니다.

--- a/src/test/java/com/whatpl/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/whatpl/chat/controller/ChatRoomControllerTest.java
@@ -1,0 +1,119 @@
+package com.whatpl.chat.controller;
+
+import com.whatpl.ApiDocTag;
+import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.chat.dto.ChatRoomResponse;
+import com.whatpl.global.security.model.WithMockWhatplMember;
+import com.whatpl.project.domain.enums.ApplyType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+class ChatRoomControllerTest extends BaseSecurityWebMvcTest {
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("채팅방 리스트 API Docs")
+    void readList() throws Exception {
+        // given
+        int page = 1;
+        int size = 10;
+        ChatRoomResponse chatRoomResponse = ChatRoomResponse.builder()
+                .chatRoomId(1L)
+                .applyType(ApplyType.APPLY)
+                .projectId(1L)
+                .projectTitle("프로젝트 제목")
+                .opponentId(1L)
+                .opponentNickname("상대방 닉네임")
+                .opponentProfileImgUri("상대방 프로필 URI")
+                .lastMessageContent("마지막 메시지")
+                .lastMessageTime(LocalDateTime.now(Clock.fixed(
+                        Instant.parse("2024-07-17T23:55:01.00Z"),
+                        ZoneId.of("Asia/Seoul"))))
+                .lastMessageRead(true)
+                .build();
+        SliceImpl<ChatRoomResponse> chatRoomResponses = new SliceImpl<>(List.of(chatRoomResponse));
+        when(chatRoomService.readChatRooms(any(Pageable.class), anyLong())).thenReturn(chatRoomResponses);
+
+        // expected
+        mockMvc.perform(get("/chat/rooms")
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
+                )
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON_VALUE),
+                        jsonPath("$.list[*].chatRoomId").value(Long.valueOf(chatRoomResponse.getChatRoomId()).intValue()),
+                        jsonPath("$.list[*].applyType").value(chatRoomResponse.getApplyType().name()),
+                        jsonPath("$.list[*].projectId").value(Long.valueOf(chatRoomResponse.getProjectId()).intValue()),
+                        jsonPath("$.list[*].projectTitle").value(chatRoomResponse.getProjectTitle()),
+                        jsonPath("$.list[*].opponentId").value(Long.valueOf(chatRoomResponse.getOpponentId()).intValue()),
+                        jsonPath("$.list[*].opponentNickname").value(chatRoomResponse.getOpponentNickname()),
+                        jsonPath("$.list[*].opponentProfileImgUri").value(chatRoomResponse.getOpponentProfileImgUri()),
+                        jsonPath("$.list[*].lastMessageContent").value(chatRoomResponse.getLastMessageContent()),
+                        jsonPath("$.list[*].lastMessageTime").value(chatRoomResponse.getLastMessageTime().toString()),
+                        jsonPath("$.list[*].lastMessageRead").value(chatRoomResponse.isLastMessageRead())
+                )
+                .andDo(print())
+                .andDo(document("read-chat-room-list",
+                        resourceDetails().tag(ApiDocTag.CHAT_ROOM.getTag())
+                                .summary("채팅방 리스트")
+                                .description("""
+                                        프로젝트 리스트를 조회합니다.
+                                                                                
+                                        [ApplyType]
+                                        - APPLY: 지원자가 프로젝트에 지원한 채팅방
+                                        - OFFER: 모집자가 프로젝트에 합류 제안한 채팅방
+                                        """),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 사이즈")
+                        ),
+                        responseFields(
+                                fieldWithPath("list").type(JsonFieldType.ARRAY).description("채팅방 리스트"),
+                                fieldWithPath("list[].chatRoomId").type(JsonFieldType.NUMBER).description("채팅방 ID"),
+                                fieldWithPath("list[].applyType").type(JsonFieldType.STRING).description("채팅방 지원 타입"),
+                                fieldWithPath("list[].projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
+                                fieldWithPath("list[].projectTitle").type(JsonFieldType.STRING).description("프로젝트 제목"),
+                                fieldWithPath("list[].opponentId").type(JsonFieldType.NUMBER).description("상대방 멤버 ID"),
+                                fieldWithPath("list[].opponentNickname").type(JsonFieldType.STRING).description("상대방 멤버 닉네임"),
+                                fieldWithPath("list[].opponentProfileImgUri").type(JsonFieldType.STRING).description("상대방 멤버 프로필 이미지 URI"),
+                                fieldWithPath("list[].lastMessageContent").type(JsonFieldType.STRING).description("마지막 메시지 내용"),
+                                fieldWithPath("list[].lastMessageTime").type(JsonFieldType.STRING).description("마지막 메시지 발송 일시"),
+                                fieldWithPath("list[].lastMessageRead").type(JsonFieldType.BOOLEAN).description("마지막 메시지 읽음 여부"),
+                                fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),
+                                fieldWithPath("pageSize").type(JsonFieldType.NUMBER).description("페이지 사이즈"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("빈 리스트 여부")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #40

## 📝작업 내용

- 채팅방 리스트를 조회하는 기능을 구현하였습니다.
- 채팅방은 본인이 참여한 채팅방 리스트만 조회 가능합니다. (로그인한 사용자가 프로젝트 모집자이거나, 지원자인 채팅방)