### PR TITLE
채팅방에 해당하는 메시지만 조회

### DIFF
--- a/src/main/java/com/whatpl/chat/repository/ChatMessageQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/chat/repository/ChatMessageQueryRepositoryImpl.java
@@ -33,6 +33,7 @@ public class ChatMessageQueryRepositoryImpl implements ChatMessageQueryRepositor
                 ))
                 .from(chatMessage)
                 .leftJoin(chatMessage.sender, sender)
+                .where(chatMessage.chatRoom.id.eq(chatRoomId))
                 .orderBy(chatMessage.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageSize + 1)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #40

## 📝작업 내용

- 채팅방에 해당하지 않는 메시지가 조회되는 버그가 있어 수정하였습니다.