### PR TITLE
로컬 DB 도커 세팅

### DIFF
--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -1,9 +1,25 @@
-version: "3"
-
 services:
   redis:
     container_name: redis
-    image: redis:6
+    image: redis:7
     command: redis-server --requirepass localpassword
     ports:
       - 6379:6379
+    environment:
+      - TZ=Asia/Seoul # TimeZone 설정
+
+  mysql:
+    container_name: mysql
+    image: mysql:8.0.36
+    ports:
+      - 3306:3306
+    environment:
+      - TZ=Asia/Seoul # TimeZone 설정
+      - MYSQL_DATABASE=whatpl_local
+      - MYSQL_USER=local_user
+      - MYSQL_PASSWORD=local_password
+      - MYSQL_ROOT_PASSWORD=local_password
+      - character-set-server utf8mb4
+      - collation-server utf8mb4_general_ci
+      - default-character-set utf8mb4
+      - default-collation utf8mb4_general_ci


### PR DESCRIPTION
## 📝작업 내용

- infra/local/docker-compose.yml 을 수정했습니다.
  - AWS RDS의 VPC 퍼블릭 액세스 과금 정책으로 인해 개발자 PC에서 RDS에 직접 접근하기 어렵다고 판단했습니다.
  - 따라서, 개발자 로컬 작업 시 각자 Docker에 RDB 구동하는 방식으로 변경합니다.
