### PR TITLE
JWT 사용자 정보 Claim 추가

### DIFF
--- a/src/main/java/com/whatpl/global/common/domain/enums/Career.java
+++ b/src/main/java/com/whatpl/global/common/domain/enums/Career.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 @Getter
 @RequiredArgsConstructor
@@ -30,5 +31,12 @@ public enum Career implements WhatplGlobalDomain {
                 .filter(career -> career.getValue().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new BizException(ErrorCode.CAREER_NOT_VALID));
+    }
+
+    public static Career ifNotMatched(String value, Supplier<Career> careerSupplier) {
+        return Arrays.stream(Career.values())
+                .filter(career -> career.getValue().equals(value))
+                .findFirst()
+                .orElseGet(careerSupplier);
     }
 }

--- a/src/main/java/com/whatpl/global/common/domain/enums/Job.java
+++ b/src/main/java/com/whatpl/global/common/domain/enums/Job.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 @Getter
 @RequiredArgsConstructor
@@ -30,5 +31,12 @@ public enum Job implements WhatplGlobalDomain {
                 .filter(job -> job.getValue().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new BizException(ErrorCode.JOB_NOT_VALID));
+    }
+
+    public static Job ifNotMatched(String value, Supplier<Job> jobSupplier) {
+        return Arrays.stream(Job.values())
+                .filter(job -> job.getValue().equals(value))
+                .findFirst()
+                .orElseGet(jobSupplier);
     }
 }

--- a/src/main/java/com/whatpl/global/jwt/WhatplClaim.java
+++ b/src/main/java/com/whatpl/global/jwt/WhatplClaim.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum WhatplClaim {
 
     NICKNAME("nick"),
-    HAS_PROFILE("hpf");
+    HAS_PROFILE("hpf"),
+    JOB("job"),
+    CAREER("car");
 
     private final String key;
 }

--- a/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
+++ b/src/main/java/com/whatpl/global/security/domain/MemberPrincipal.java
@@ -1,6 +1,9 @@
 package com.whatpl.global.security.domain;
 
+import com.whatpl.global.common.domain.enums.Career;
+import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.member.domain.Member;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -10,16 +13,21 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+@Getter
 public class MemberPrincipal extends User implements OAuth2User {
 
-    @Getter
     private final long id;
     private final boolean hasProfile;
+    private final Job job;
+    private final Career career;
 
-    public MemberPrincipal(long id, boolean hasProfile, String username, String password, Collection<? extends GrantedAuthority> authorities) {
+    @Builder(builderMethodName = "memberPrincipalBuilder")
+    public MemberPrincipal(long id, boolean hasProfile, Job job, Career career, String username, String password, Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
         this.id = id;
         this.hasProfile = hasProfile;
+        this.job = job;
+        this.career = career;
     }
 
     @Override
@@ -37,6 +45,14 @@ public class MemberPrincipal extends User implements OAuth2User {
     }
 
     public static MemberPrincipal from(Member member) {
-        return new MemberPrincipal(member.getId(), member.hasProfile(), member.getNickname(), "", Collections.emptySet());
+        return MemberPrincipal.memberPrincipalBuilder()
+                .id(member.getId())
+                .hasProfile(member.hasProfile())
+                .job(member.getJob())
+                .career(member.getCareer())
+                .username(member.getNickname())
+                .password("")
+                .authorities(Collections.emptySet())
+                .build();
     }
 }

--- a/src/test/java/com/whatpl/global/authentication/MemberPrincipalFixture.java
+++ b/src/test/java/com/whatpl/global/authentication/MemberPrincipalFixture.java
@@ -1,0 +1,25 @@
+package com.whatpl.global.authentication;
+
+import com.whatpl.global.common.domain.enums.Career;
+import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.security.domain.MemberPrincipal;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberPrincipalFixture {
+
+    public static MemberPrincipal create() {
+        return MemberPrincipal.memberPrincipalBuilder()
+                .id(1L)
+                .hasProfile(true)
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.FIVE)
+                .username("왓플테스트멤버")
+                .password("")
+                .authorities(Collections.emptySet())
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/whatpl/global/security/filter/JwtAuthenticationFilterTest.java
@@ -1,6 +1,7 @@
 package com.whatpl.global.security.filter;
 
 import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.global.authentication.MemberPrincipalFixture;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ class JwtAuthenticationFilterTest extends BaseSecurityWebMvcTest {
         // given: 토큰이 유효한 경우로 세팅
         String tokenType = "Bearer";
         String validToken = "validToken";
-        var principal = new MemberPrincipal(1L, true, "test", "", Collections.emptySet());
+        MemberPrincipal principal = MemberPrincipalFixture.create();
         var authenticationToken = new UsernamePasswordAuthenticationToken(principal, "", Collections.emptySet());
         when(jwtService.resolveToken(any()))
                 .thenReturn(authenticationToken);

--- a/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
+++ b/src/test/java/com/whatpl/global/security/jwt/JwtServiceTest.java
@@ -1,5 +1,6 @@
 package com.whatpl.global.security.jwt;
 
+import com.whatpl.global.authentication.MemberPrincipalFixture;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.jwt.JwtProperties;
@@ -8,6 +9,7 @@ import com.whatpl.global.jwt.JwtService;
 import com.whatpl.global.redis.RedisService;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.member.domain.Member;
+import com.whatpl.member.model.MemberFixture;
 import com.whatpl.member.repository.MemberRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -24,10 +26,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 
-import java.util.Collections;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +53,7 @@ class JwtServiceTest {
     @DisplayName("accessToken 을 발급한다.")
     void createAccessToken() {
         // given
-        MemberPrincipal principal = new MemberPrincipal(1L, false, "testuser", "", Collections.emptySet());
+        MemberPrincipal principal = MemberPrincipalFixture.create();
         OAuth2AuthenticationToken oAuth2AuthenticationToken = new OAuth2AuthenticationToken(principal, null, "test");
 
         when(jwtProperties.getAccessExpirationTime())
@@ -163,12 +165,10 @@ class JwtServiceTest {
                 .thenReturn(true);
         when(redisService.get(any()))
                 .thenReturn(String.valueOf(memberId));
-        Member testMember = Member.builder()
-                .nickname("testMember")
-                .build();
+        Member testMember = MemberFixture.withAll();
         when(memberRepository.findMemberWithAllById(memberId))
                 .thenReturn(Optional.of(testMember));
-        MemberPrincipal expectedPrincipal = new MemberPrincipal(memberId, false, testMember.getNickname(), "", Collections.emptySet());
+        MemberPrincipal expectedPrincipal = MemberPrincipalFixture.create();
         MockedStatic<MemberPrincipal> memberPrincipalMock = mockStatic(MemberPrincipal.class);
         memberPrincipalMock.when(() -> MemberPrincipal.from(testMember))
                 .thenReturn(expectedPrincipal);

--- a/src/test/java/com/whatpl/global/security/model/WithMockWhatplMember.java
+++ b/src/test/java/com/whatpl/global/security/model/WithMockWhatplMember.java
@@ -1,5 +1,7 @@
 package com.whatpl.global.security.model;
 
+import com.whatpl.global.common.domain.enums.Career;
+import com.whatpl.global.common.domain.enums.Job;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.security.test.context.support.WithSecurityContext;
 
@@ -17,6 +19,10 @@ public @interface WithMockWhatplMember {
     long id() default 1L;
 
     boolean hasProfile() default true;
+
+    Job job() default Job.BACKEND_DEVELOPER;
+
+    Career career() default Career.FIVE;
 
     @AliasFor("id")
     long value() default 1L;

--- a/src/test/java/com/whatpl/global/security/model/WithMockWhatplMemberSecurityContextFactory.java
+++ b/src/test/java/com/whatpl/global/security/model/WithMockWhatplMemberSecurityContextFactory.java
@@ -14,7 +14,15 @@ public class WithMockWhatplMemberSecurityContextFactory implements WithSecurityC
     @Override
     public SecurityContext createSecurityContext(WithMockWhatplMember whatplMember) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        MemberPrincipal principal = new MemberPrincipal(whatplMember.id(), whatplMember.hasProfile(), "왓플테스트유저", "", Collections.emptySet());
+        MemberPrincipal principal = MemberPrincipal.memberPrincipalBuilder()
+                .id(whatplMember.id())
+                .hasProfile(whatplMember.hasProfile())
+                .job(whatplMember.job())
+                .career(whatplMember.career())
+                .username("왓플테스트유저")
+                .password("")
+                .authorities(Collections.emptySet())
+                .build();
         Authentication auth = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
         context.setAuthentication(auth);
         return context;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #6

## 📝작업 내용

- JWT 페이로드에 사용자 정보 Claim을 추가 했습니다.
- 추가된 Claim 목록
  - job: 직무
  - car: 경력