### PR TITLE
프로젝트 리스트 Cache 적용

### DIFF
--- a/src/main/java/com/whatpl/global/config/CacheConfig.java
+++ b/src/main/java/com/whatpl/global/config/CacheConfig.java
@@ -1,0 +1,34 @@
+package com.whatpl.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30L))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class)));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(defaultConfig)
+                .build();
+    }
+}

--- a/src/main/java/com/whatpl/project/controller/ProjectController.java
+++ b/src/main/java/com/whatpl/project/controller/ProjectController.java
@@ -4,6 +4,7 @@ import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.global.pagination.SliceResponse;
 import com.whatpl.global.security.domain.MemberPrincipal;
+import com.whatpl.global.util.PaginationUtils;
 import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.dto.*;
 import com.whatpl.project.service.ProjectReadService;
@@ -11,13 +12,14 @@ import com.whatpl.project.service.ProjectWriteService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,8 +55,9 @@ public class ProjectController {
             throw new BizException(ErrorCode.PROJECT_STATUS_NOT_VALID);
         }
         searchCondition.assignLoginMember(principal);
-        Slice<ProjectInfo> projects = projectReadService.searchProjectList(pageable, searchCondition);
-        return ResponseEntity.ok(new SliceResponse<>(projects));
+        List<ProjectInfo> projectInfos = projectReadService.searchProjectList(pageable, searchCondition);
+        SliceImpl<ProjectInfo> result = new SliceImpl<>(projectInfos, pageable, PaginationUtils.hasNext(projectInfos, pageable.getPageSize()));
+        return ResponseEntity.ok(new SliceResponse<>(result));
     }
 
     @PreAuthorize("hasPermission(#projectId, 'PROJECT', 'UPDATE')")

--- a/src/main/java/com/whatpl/project/domain/RecruitJob.java
+++ b/src/main/java/com/whatpl/project/domain/RecruitJob.java
@@ -40,4 +40,8 @@ public class RecruitJob extends BaseTimeEntity {
         }
         this.recruitAmount = recruitAmount;
     }
+
+    public boolean isJobMatched(ProjectParticipant participant) {
+        return this.getJob().equals(participant.getJob());
+    }
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
@@ -8,6 +8,7 @@ import com.whatpl.project.domain.enums.ProjectStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 @Getter
 @Builder
@@ -26,5 +27,13 @@ public class ProjectSearchCondition {
             return;
         }
         longinMemberId = principal != null ? principal.getId() : Long.MIN_VALUE;
+    }
+
+    public boolean isEmpty() {
+        return this.subject == null &&
+                this.job == null &&
+                this.skill == null &&
+                this.profitable == null &&
+                !StringUtils.hasText(this.keyword);
     }
 }

--- a/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/whatpl/project/dto/ProjectSearchCondition.java
@@ -1,5 +1,7 @@
 package com.whatpl.project.dto;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.common.domain.enums.Skill;
 import com.whatpl.global.common.domain.enums.Subject;
@@ -8,12 +10,18 @@ import com.whatpl.project.domain.enums.ProjectStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Sort;
 import org.springframework.util.StringUtils;
+
+import java.util.Optional;
+
+import static com.whatpl.project.domain.QProject.project;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class ProjectSearchCondition {
+
     private Subject subject;
     private Job job;
     private Skill skill;
@@ -35,5 +43,28 @@ public class ProjectSearchCondition {
                 this.skill == null &&
                 this.profitable == null &&
                 !StringUtils.hasText(this.keyword);
+    }
+
+    public enum OrderType {
+        LATEST {
+            @Override
+            public Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order) {
+                if (order.getProperty().equalsIgnoreCase(name())) {
+                    return Optional.of(new OrderSpecifier<>(Order.DESC, project.createdAt));
+                }
+                return Optional.empty();
+            }
+        },
+        POPULAR {
+            @Override
+            public Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order) {
+                if (order.getProperty().equalsIgnoreCase(ProjectSearchCondition.OrderType.POPULAR.name())) {
+                    return Optional.of(new OrderSpecifier<>(Order.DESC, project.views));
+                }
+                return Optional.empty();
+            }
+        };
+
+        public abstract Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order);
     }
 }

--- a/src/main/java/com/whatpl/project/dto/RemainedJobDto.java
+++ b/src/main/java/com/whatpl/project/dto/RemainedJobDto.java
@@ -1,8 +1,12 @@
 package com.whatpl.project.dto;
 
 import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.project.domain.ProjectParticipant;
+import com.whatpl.project.domain.RecruitJob;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class RemainedJobDto {
@@ -16,5 +20,15 @@ public class RemainedJobDto {
         this.job = job;
         this.recruitAmount = recruitAmount;
         this.remainedAmount = remainedAmount;
+    }
+
+    public static RemainedJobDto of(RecruitJob recruitJob, List<ProjectParticipant> participants) {
+        return RemainedJobDto.builder()
+                .job(recruitJob.getJob())
+                .recruitAmount(recruitJob.getRecruitAmount())
+                .remainedAmount(recruitJob.getRecruitAmount() - participants.stream()
+                        .filter(recruitJob::isJobMatched)
+                        .toList().size())
+                .build();
     }
 }

--- a/src/main/java/com/whatpl/project/service/ProjectApplyService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectApplyService.java
@@ -19,6 +19,7 @@ import com.whatpl.project.repository.ApplyRepository;
 import com.whatpl.project.repository.ProjectParticipantRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,6 +67,8 @@ public class ProjectApplyService {
 
     @Transactional
     @DistributedLock(name = "'project:'.concat(#projectId)")
+    @CacheEvict(value = "projectList", allEntries = true,
+            condition = "T(com.whatpl.global.common.domain.enums.ApplyStatus).ACCEPTED.equals(#applyStatus)")
     public void status(final long projectId, final long applyId, final ApplyStatus applyStatus) {
         Project project = projectRepository.findWithRecruitJobsById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/whatpl/project/service/ProjectCommentService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectCommentService.java
@@ -14,6 +14,7 @@ import com.whatpl.project.dto.ProjectCommentUpdateRequest;
 import com.whatpl.project.repository.ProjectCommentRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ public class ProjectCommentService {
     private final ProjectCommentRepository projectCommentRepository;
 
     @Transactional
+    @CacheEvict(value = "projectList", allEntries = true)
     public void createProjectComment(final ProjectCommentCreateRequest request, final long projectId, final long writerId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/whatpl/project/service/ProjectLikeService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectLikeService.java
@@ -9,6 +9,7 @@ import com.whatpl.project.domain.ProjectLike;
 import com.whatpl.project.repository.ProjectLikeRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class ProjectLikeService {
     private final ProjectLikeRepository projectLikeRepository;
 
     @Transactional
+    @CacheEvict(value = "projectList", allEntries = true)
     public long putLike(final long projectId, final long memberId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
@@ -35,6 +37,7 @@ public class ProjectLikeService {
     }
 
     @Transactional
+    @CacheEvict(value = "projectList", allEntries = true)
     public void deleteLike(final long projectId, final long memberId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/whatpl/project/service/ProjectParticipantService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectParticipantService.java
@@ -1,15 +1,16 @@
 package com.whatpl.project.service;
 
 import com.whatpl.global.aop.annotation.DistributedLock;
+import com.whatpl.global.common.domain.enums.ApplyStatus;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.project.domain.Project;
 import com.whatpl.project.domain.ProjectParticipant;
-import com.whatpl.global.common.domain.enums.ApplyStatus;
 import com.whatpl.project.repository.ApplyRepository;
 import com.whatpl.project.repository.ProjectParticipantRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class ProjectParticipantService {
 
     @Transactional
     @DistributedLock(name = "'project:'.concat(#projectId)")
+    @CacheEvict(value = "projectList", allEntries = true)
     public void deleteParticipant(final long projectId, final long participantId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/whatpl/project/service/ProjectReadAsyncService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectReadAsyncService.java
@@ -49,12 +49,7 @@ public class ProjectReadAsyncService {
                         List<RecruitJob> recruitJobs = recruitJobMap.get(projectId);
                         List<ProjectParticipant> participants = Optional.ofNullable(participantMap.get(projectId)).orElseGet(Collections::emptyList);
                         List<RemainedJobDto> remainedJobs = recruitJobs.stream()
-                                .map(recruitJob -> RemainedJobDto.builder()
-                                        .job(recruitJob.getJob())
-                                        .recruitAmount(recruitJob.getRecruitAmount())
-                                        .remainedAmount(recruitJobs.size() - participants.size())
-                                        .build())
-                                .filter(remainedJob -> remainedJob.getRemainedAmount() != 0)
+                                .map(recruitJob -> RemainedJobDto.of(recruitJob, participants))
                                 .toList();
                         projectInfo.setRemainedJobs(remainedJobs);
                     });

--- a/src/main/java/com/whatpl/project/service/ProjectWriteService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectWriteService.java
@@ -14,6 +14,7 @@ import com.whatpl.project.dto.ProjectCreateRequest;
 import com.whatpl.project.dto.ProjectUpdateRequest;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ public class ProjectWriteService {
     private final ProjectRepository projectRepository;
 
     @Transactional
+    @CacheEvict(value = "projectList", allEntries = true)
     public Long createProject(final ProjectCreateRequest request, final Long memberId) {
         Member writer = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
@@ -39,6 +41,7 @@ public class ProjectWriteService {
 
     @Transactional
     @DistributedLock(name = "'project:'.concat(#projectId)")
+    @CacheEvict(value = "projectList", allEntries = true)
     public void modifyProject(final Long projectId, final ProjectUpdateRequest request) {
         Attachment representImage = getRepresentImage(request.getRepresentImageId());
         Project project = projectRepository.findWithRecruitJobsById(projectId)
@@ -59,6 +62,7 @@ public class ProjectWriteService {
 
     @Transactional
     @DistributedLock(name = "'project:'.concat(#projectId)")
+    @CacheEvict(value = "projectList", allEntries = true)
     public void deleteProject(final Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));

--- a/src/main/java/com/whatpl/project/util/ProjectCacheUtils.java
+++ b/src/main/java/com/whatpl/project/util/ProjectCacheUtils.java
@@ -1,0 +1,20 @@
+package com.whatpl.project.util;
+
+import com.whatpl.project.dto.ProjectSearchCondition;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProjectCacheUtils {
+
+    public static String buildListCacheKey(ProjectSearchCondition searchCondition) {
+        return searchCondition.getStatus() != null ? searchCondition.getStatus().name().toLowerCase() : "all";
+    }
+
+    public static boolean isCacheable(Pageable pageable, ProjectSearchCondition searchCondition) {
+        return pageable.getPageNumber() == 0 &&
+                (pageable.getSort().isEmpty() || pageable.getSort().getOrderFor("latest") != null) &&
+                searchCondition.isEmpty();
+    }
+}

--- a/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectControllerTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -209,7 +208,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .representImageUri("/images/default?type=project")
                 .myLike(true)
                 .build();
-        SliceImpl<ProjectInfo> projectInfos = new SliceImpl<>(List.of(projectInfo));
+        List<ProjectInfo> projectInfos = List.of(projectInfo);
         ProjectSearchCondition searchCondition = ProjectSearchCondition.builder()
                 .subject(Subject.SOCIAL_MEDIA)
                 .status(ProjectStatus.RECRUITING)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #58

## 📝작업 내용

- 프로젝트 리스트 첫 페이지를 Redis에 캐싱하였습니다.
  - 저장 전략은 Look Aside 이고, 쓰기 전략은 Write Around 입니다. [[REDIS] 📚 캐시(Cache) 설계 전략 지침 💯 총정리](https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-%EC%BA%90%EC%8B%9CCache-%EC%84%A4%EA%B3%84-%EC%A0%84%EB%9E%B5-%EC%A7%80%EC%B9%A8-%EC%B4%9D%EC%A0%95%EB%A6%AC)
  - 프로젝트 등록/수정/삭제 등의 이벤트가 발생하면 캐시를 만료시킵니다.
- 몇몇 코드를 refactoring 하였습니다.
  - Stream 가독성 개선을 위해 람다식 -> 메서드 참조로 변경하였습니다. 같은 이유로 생성 메서드를 람다식 -> 정적 팩토리 메서드로 변경하였습니다.
  - 프로젝트 리스트 정렬 조건의 쿼리 생성 책임을 분리하였습니다. 기존에 repository에서 정렬 조건에 따라 쿼리를 생성했는데, 정렬조건이 추가될 경우 쿼리 생성이 누락될 가능성이 있어서 정렬 조건 enum을 만들고, abstract 메서드를 추가해 쿼리 생성을 강제하였습니다.