### PR TITLE
도메인 로직 분리

### DIFF
--- a/src/main/java/com/whatpl/project/domain/RecruitJob.java
+++ b/src/main/java/com/whatpl/project/domain/RecruitJob.java
@@ -2,6 +2,8 @@ package com.whatpl.project.domain;
 
 import com.whatpl.global.common.BaseTimeEntity;
 import com.whatpl.global.common.domain.enums.Job;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -42,6 +44,22 @@ public class RecruitJob extends BaseTimeEntity {
     }
 
     public boolean isJobMatched(ProjectParticipant participant) {
-        return this.getJob().equals(participant.getJob());
+        return this.job.equals(participant.getJob());
+    }
+
+    public boolean isJobMatched(Job job) {
+        return this.job.equals(job);
+    }
+
+    /**
+     * 모집인원이 가득 찼는지 검증합니다.
+     */
+    public void validateFullJob() {
+        long participantAmount = project.getProjectParticipants().stream()
+                .filter(participant -> participant.getJob().equals(job))
+                .count();
+        if (recruitAmount <= participantAmount) {
+            throw new BizException(ErrorCode.RECRUIT_COMPLETED_APPLY_JOB);
+        }
     }
 }

--- a/src/main/java/com/whatpl/project/domain/enums/ProjectStatus.java
+++ b/src/main/java/com/whatpl/project/domain/enums/ProjectStatus.java
@@ -15,7 +15,8 @@ public enum ProjectStatus {
 
     RECRUITING("모집중"),
     COMPLETED("모집완료"),
-    DELETED("삭제");
+    DELETED("삭제"),
+    ALL("전체");
 
     @JsonValue
     private final String value;

--- a/src/main/java/com/whatpl/project/service/ProjectApplyService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectApplyService.java
@@ -3,20 +3,15 @@ package com.whatpl.project.service;
 import com.whatpl.chat.service.ChatRoomService;
 import com.whatpl.global.aop.annotation.DistributedLock;
 import com.whatpl.global.common.domain.enums.ApplyStatus;
-import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.member.domain.Member;
 import com.whatpl.member.repository.MemberRepository;
 import com.whatpl.project.domain.Apply;
 import com.whatpl.project.domain.Project;
-import com.whatpl.project.domain.ProjectParticipant;
-import com.whatpl.project.domain.RecruitJob;
-import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.dto.ApplyResponse;
 import com.whatpl.project.dto.ProjectApplyRequest;
 import com.whatpl.project.repository.ApplyRepository;
-import com.whatpl.project.repository.ProjectParticipantRepository;
 import com.whatpl.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -30,7 +25,6 @@ public class ProjectApplyService {
     private final MemberRepository memberRepository;
     private final ProjectRepository projectRepository;
     private final ApplyRepository applyRepository;
-    private final ProjectParticipantRepository projectParticipantRepository;
     private final ChatRoomService chatRoomService;
 
     @Transactional
@@ -40,22 +34,10 @@ public class ProjectApplyService {
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_PROJECT));
         Member applicant = memberRepository.findById(applicantId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
-
-        // 삭제된 프로젝트는 지원 불가
-        validateDeletedProject(project);
-        // 모집완료된 프로젝트는 지원 불가
-        validateCompletedRecruitment(project);
-        // 프로젝트 등록자는 본인이 등록한 프로젝트에 지원 불가
-        validateWriter(project, applicant);
-        // 모집직군에 지원하는 직무가 없을 경우, 모집직군에 지원하는 직무가 마감된 경우 지원 불가
-        validateFullJob(project, request.getApplyJob());
-        // 이미 지원한 프로젝트는 지원 불가
-        validateDuplicatedApply(project, applicant);
+        project.validateCanApply(applicant, request.getApplyJob());
 
         Apply apply = Apply.of(request.getApplyJob(), request.getApplyType(), applicant, project);
         Apply savedApply = applyRepository.save(apply);
-
-        // 지원 쪽지 발송
         long chatRoomId = chatRoomService.createChatRoom(apply, request.getContent());
 
         return ApplyResponse.builder()
@@ -77,61 +59,6 @@ public class ProjectApplyService {
         if (!project.getId().equals(apply.getProject().getId())) {
             throw new BizException(ErrorCode.NOT_MATCH_PROJECT_APPLY);
         }
-        // 지원서의 상태를 승인/거절 상태로 변경한다. 만약, 이미 처리된 지원서라면 BizException 발생
-        apply.changeStatus(applyStatus);
-        if (applyStatus.equals(ApplyStatus.ACCEPTED)) {
-            // 지원서 승인일 경우 지원자를 프로젝트에 참여시킨다.
-            participate(project, apply.getApplicant(), apply.getJob());
-        }
-    }
-
-    private void participate(Project project, Member participant, Job job) {
-        // 만약, 모집인원이 초과될 경우 BizException 발생
-        validateFullJob(project, job);
-        ProjectParticipant projectParticipant = ProjectParticipant.builder()
-                .project(project)
-                .participant(participant)
-                .job(job)
-                .build();
-        projectParticipantRepository.save(projectParticipant);
-    }
-
-    private void validateDeletedProject(Project project) {
-        if (project.getStatus().equals(ProjectStatus.DELETED)) {
-            throw new BizException(ErrorCode.DELETED_PROJECT);
-        }
-    }
-
-    private void validateCompletedRecruitment(Project project) {
-        if (project.getStatus().equals(ProjectStatus.COMPLETED)) {
-            throw new BizException(ErrorCode.COMPLETED_RECRUITMENT);
-        }
-    }
-
-    private void validateWriter(Project project, Member applicant) {
-        if (project.getWriter().equals(applicant)) {
-            throw new BizException(ErrorCode.WRITER_NOT_APPLY);
-        }
-    }
-
-    private void validateFullJob(Project project, Job applyJob) {
-        RecruitJob matchedRecruitJob = project.getRecruitJobs().stream()
-                .filter(recruitJob -> recruitJob.getJob().equals(applyJob))
-                .findFirst()
-                .orElseThrow(() -> new BizException(ErrorCode.NOT_MATCH_APPLY_JOB_WITH_PROJECT));
-        int recruitAmount = matchedRecruitJob.getRecruitAmount();
-        int participantAmount = projectParticipantRepository.countByProjectIdAndJob(project.getId(), applyJob);
-        if (recruitAmount <= participantAmount) {
-            throw new BizException(ErrorCode.RECRUIT_COMPLETED_APPLY_JOB);
-        }
-    }
-
-    private void validateDuplicatedApply(Project project, Member applicant) {
-        boolean isDuplicated = applyRepository.findByProjectAndApplicant(project, applicant)
-                .isPresent();
-
-        if (isDuplicated) {
-            throw new BizException(ErrorCode.DUPLICATED_APPLY);
-        }
+        apply.processApply(project, applyStatus);
     }
 }

--- a/src/main/java/com/whatpl/project/service/ProjectReadService.java
+++ b/src/main/java/com/whatpl/project/service/ProjectReadService.java
@@ -33,8 +33,8 @@ public class ProjectReadService {
         boolean myLike = projectLikeRepository.existsByProjectIdAndMemberId(projectId, memberId);
 
         long likes = projectLikeRepository.countByProject(project);
-        // 조회수 증가
         project.increaseViews();
+
         return ProjectModelConverter.toProjectReadResponse(project, likes, myLike);
     }
 

--- a/src/main/java/com/whatpl/project/util/ProjectCacheUtils.java
+++ b/src/main/java/com/whatpl/project/util/ProjectCacheUtils.java
@@ -1,5 +1,6 @@
 package com.whatpl.project.util;
 
+import com.whatpl.project.domain.enums.ProjectStatus;
 import com.whatpl.project.dto.ProjectSearchCondition;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -9,12 +10,15 @@ import org.springframework.data.domain.Pageable;
 public class ProjectCacheUtils {
 
     public static String buildListCacheKey(ProjectSearchCondition searchCondition) {
-        return searchCondition.getStatus() != null ? searchCondition.getStatus().name().toLowerCase() : "all";
+        return searchCondition.getStatus() != null ?
+                searchCondition.getStatus().name().toLowerCase() :
+                ProjectStatus.ALL.name().toLowerCase();
     }
 
     public static boolean isCacheable(Pageable pageable, ProjectSearchCondition searchCondition) {
+        String latest = ProjectSearchCondition.OrderType.LATEST.name().toLowerCase();
         return pageable.getPageNumber() == 0 &&
-                (pageable.getSort().isEmpty() || pageable.getSort().getOrderFor("latest") != null) &&
+                (pageable.getSort().isEmpty() || pageable.getSort().getOrderFor(latest) != null) &&
                 searchCondition.isEmpty();
     }
 }

--- a/src/test/java/com/whatpl/project/controller/ProjectApplyControllerTest.java
+++ b/src/test/java/com/whatpl/project/controller/ProjectApplyControllerTest.java
@@ -2,6 +2,7 @@ package com.whatpl.project.controller;
 
 import com.whatpl.ApiDocTag;
 import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.global.common.domain.enums.Job;
 import com.whatpl.global.security.model.WithMockWhatplMember;
 import com.whatpl.global.common.domain.enums.ApplyStatus;
 import com.whatpl.project.dto.ApplyResponse;
@@ -45,7 +46,7 @@ class ProjectApplyControllerTest extends BaseSecurityWebMvcTest {
     @DisplayName("프로젝트 지원 API Docs")
     void apply() throws Exception {
         // given
-        ProjectApplyRequest request = ProjectApplyRequestFixture.apply();
+        ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);
         Map<String, Object> map = Map.of(
                 "applyJob", request.getApplyJob(),
                 "content", request.getContent(),

--- a/src/test/java/com/whatpl/project/model/ProjectApplyRequestFixture.java
+++ b/src/test/java/com/whatpl/project/model/ProjectApplyRequestFixture.java
@@ -6,9 +6,9 @@ import com.whatpl.project.dto.ProjectApplyRequest;
 
 public class ProjectApplyRequestFixture {
 
-    public static ProjectApplyRequest apply() {
+    public static ProjectApplyRequest apply(Job applyJob) {
         return ProjectApplyRequest.builder()
-                .applyJob(Job.BACKEND_DEVELOPER)
+                .applyJob(applyJob)
                 .content("test content")
                 .applyType(ApplyType.APPLY)
                 .build();


### PR DESCRIPTION
## 📝작업 내용

- 코드 refactoring 진행하였습니다.
  - 비즈니스 로직에 작성되어 있던 도메인 로직을 각 도메인으로 분리시켰습니다.
  - 문자열로 되어 있던 코드를 enum으로 변경하였습니다.
  - 리스트 Caching 애노테이션의 SpEL이 너무 길어져 가독성을 해치고 있어 유틸 클래스로 분리시켰습니다.