### PR TITLE
Setter 제거 및 변경 범위 최소화

### DIFF
--- a/src/main/java/com/whatpl/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/whatpl/domain/chat/domain/ChatMessage.java
@@ -27,13 +27,13 @@ public class ChatMessage extends BaseTimeEntity {
 
     private String content;
 
-    @Setter
     private LocalDateTime readAt;
 
     @Builder
-    public ChatMessage(Member sender, ChatRoom chatRoom, String content) {
+    public ChatMessage(Member sender, ChatRoom chatRoom, String content, LocalDateTime readAt) {
         this.sender = sender;
         this.chatRoom = chatRoom;
         this.content = content;
+        this.readAt = readAt;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/Member.java
+++ b/src/main/java/com/whatpl/domain/member/domain/Member.java
@@ -38,7 +38,6 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Career career;
 
-    @Setter
     @Enumerated(EnumType.STRING)
     private WorkTime workTime;
 
@@ -172,5 +171,9 @@ public class Member extends BaseTimeEntity {
                 .orElseGet(Collections::emptySet).stream()
                 .map(MemberReference::new)
                 .forEach(this::addMemberReference);
+    }
+
+    public void modifyWorkTime(@NonNull WorkTime workTime) {
+        this.workTime = workTime;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/Member.java
+++ b/src/main/java/com/whatpl/domain/member/domain/Member.java
@@ -78,7 +78,7 @@ public class Member extends BaseTimeEntity {
             throw new BizException(ErrorCode.MAX_SKILL_SIZE_EXCEED);
         }
         this.memberSkills.add(memberSkill);
-        memberSkill.setMember(this);
+        memberSkill.addRelation(this);
     }
 
     public void addMemberSubject(MemberSubject memberSubject) {
@@ -89,7 +89,7 @@ public class Member extends BaseTimeEntity {
             throw new BizException(ErrorCode.MAX_SUBJECT_SIZE_EXCEED);
         }
         this.memberSubjects.add(memberSubject);
-        memberSubject.setMember(this);
+        memberSubject.addRelation(this);
     }
 
     public void addMemberReference(MemberReference memberReference) {
@@ -100,7 +100,7 @@ public class Member extends BaseTimeEntity {
             throw new BizException(ErrorCode.MAX_REFERENCE_SIZE_EXCEED);
         }
         this.memberReferences.add(memberReference);
-        memberReference.setMember(this);
+        memberReference.addRelation(this);
     }
 
     public void addMemberPortfolio(MemberPortfolio memberPortfolio) {
@@ -111,7 +111,7 @@ public class Member extends BaseTimeEntity {
             throw new BizException(ErrorCode.MAX_PORTFOLIO_SIZE_EXCEED);
         }
         this.memberPortfolios.add(memberPortfolio);
-        memberPortfolio.setMember(this);
+        memberPortfolio.addRelation(this);
     }
 
     //==비즈니스 로직==//

--- a/src/main/java/com/whatpl/domain/member/domain/MemberPortfolio.java
+++ b/src/main/java/com/whatpl/domain/member/domain/MemberPortfolio.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.NonNull;
 
 @Getter
 @Entity
@@ -22,12 +22,15 @@ public class MemberPortfolio extends BaseTimeEntity {
     @JoinColumn(name = "attachment_id")
     private Attachment attachment;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     public MemberPortfolio(Attachment attachment) {
         this.attachment = attachment;
+    }
+
+    public void addRelation(@NonNull Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/MemberReference.java
+++ b/src/main/java/com/whatpl/domain/member/domain/MemberReference.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.NonNull;
 
 @Getter
 @Entity
@@ -19,12 +19,15 @@ public class MemberReference extends BaseTimeEntity {
 
     private String reference;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     public MemberReference(String reference) {
         this.reference = reference;
+    }
+
+    public void addRelation(@NonNull Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/MemberSkill.java
+++ b/src/main/java/com/whatpl/domain/member/domain/MemberSkill.java
@@ -18,12 +18,15 @@ public class MemberSkill extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Skill skill;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     public MemberSkill(Skill skill) {
         this.skill = skill;
+    }
+
+    public void addRelation(@NonNull Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/MemberSubject.java
+++ b/src/main/java/com/whatpl/domain/member/domain/MemberSubject.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.NonNull;
 
 @Getter
 @Entity
@@ -21,12 +21,15 @@ public class MemberSubject extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Subject subject;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     public MemberSubject(Subject subject) {
         this.subject = subject;
+    }
+
+    public void addRelation(@NonNull Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
@@ -52,6 +52,6 @@ public class MemberProfileService {
         memberPortfolios.forEach(member::addMemberPortfolio);
         member.modifyMemberSubject(info.getSubjects());
         member.modifyMemberReference(info.getReferences());
-        member.setWorkTime(info.getWorkTime());
+        member.modifyWorkTime(info.getWorkTime());
     }
 }

--- a/src/main/java/com/whatpl/domain/project/domain/Apply.java
+++ b/src/main/java/com/whatpl/domain/project/domain/Apply.java
@@ -32,8 +32,7 @@ public class Apply extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id")
     private Member applicant;
-
-    @Setter
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
@@ -44,6 +43,10 @@ public class Apply extends BaseTimeEntity {
         this.status = status;
         this.type = type;
         this.applicant = applicant;
+        this.project = project;
+    }
+
+    public void addRelation(@NonNull Project project) {
         this.project = project;
     }
 

--- a/src/main/java/com/whatpl/domain/project/domain/Project.java
+++ b/src/main/java/com/whatpl/domain/project/domain/Project.java
@@ -38,8 +38,7 @@ public class Project extends BaseTimeEntity {
     private Integer term;
 
     private Long views;
-
-    @Setter
+    
     @Enumerated(EnumType.STRING)
     private ProjectStatus status;
 

--- a/src/main/java/com/whatpl/domain/project/domain/Project.java
+++ b/src/main/java/com/whatpl/domain/project/domain/Project.java
@@ -100,7 +100,7 @@ public class Project extends BaseTimeEntity {
             return;
         }
         this.projectSkills.add(projectSkill);
-        projectSkill.setProject(this);
+        projectSkill.addRelation(this);
     }
 
     public void addRecruitJob(RecruitJob recruitJob) {
@@ -108,7 +108,7 @@ public class Project extends BaseTimeEntity {
             return;
         }
         this.recruitJobs.add(recruitJob);
-        recruitJob.setProject(this);
+        recruitJob.addRelation(this);
     }
 
     public void addProjectParticipant(ProjectParticipant projectParticipant) {
@@ -116,7 +116,7 @@ public class Project extends BaseTimeEntity {
             return;
         }
         this.projectParticipants.add(projectParticipant);
-        projectParticipant.setProject(this);
+        projectParticipant.addRelation(this);
     }
 
     public void addRepresentImageAndWriter(Attachment representImage, Member writer) {
@@ -129,7 +129,7 @@ public class Project extends BaseTimeEntity {
             return;
         }
         this.applies.add(apply);
-        apply.setProject(this);
+        apply.addRelation(this);
     }
 
     //==비즈니스 로직==//

--- a/src/main/java/com/whatpl/domain/project/domain/ProjectParticipant.java
+++ b/src/main/java/com/whatpl/domain/project/domain/ProjectParticipant.java
@@ -19,7 +19,6 @@ public class ProjectParticipant extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Job job;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
@@ -33,5 +32,9 @@ public class ProjectParticipant extends BaseTimeEntity {
         this.job = job;
         this.project = project;
         this.participant = participant;
+    }
+
+    public void addRelation(@NonNull Project project) {
+        this.project = project;
     }
 }

--- a/src/main/java/com/whatpl/domain/project/domain/ProjectSkill.java
+++ b/src/main/java/com/whatpl/domain/project/domain/ProjectSkill.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.NonNull;
 
 @Getter
 @Entity
@@ -21,12 +21,15 @@ public class ProjectSkill extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Skill skill;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
 
     public ProjectSkill(Skill skill) {
         this.skill = skill;
+    }
+
+    public void addRelation(@NonNull Project project) {
+        this.project = project;
     }
 }

--- a/src/main/java/com/whatpl/domain/project/domain/RecruitJob.java
+++ b/src/main/java/com/whatpl/domain/project/domain/RecruitJob.java
@@ -22,7 +22,6 @@ public class RecruitJob extends BaseTimeEntity {
 
     private Integer recruitAmount;
 
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
@@ -34,6 +33,10 @@ public class RecruitJob extends BaseTimeEntity {
         }
         this.job = job;
         this.recruitAmount = recruitAmount;
+    }
+
+    public void addRelation(@NonNull Project project) {
+        this.project = project;
     }
 
     public void changeRecruitAmount(int recruitAmount) {

--- a/src/main/java/com/whatpl/domain/project/dto/ProjectInfo.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ProjectInfo.java
@@ -5,6 +5,7 @@ import com.whatpl.global.common.model.Subject;
 import com.whatpl.global.pagination.SliceElement;
 import com.whatpl.domain.project.model.ProjectStatus;
 import lombok.*;
+import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 
@@ -13,20 +14,58 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProjectInfo implements SliceElement {
+
     private long projectId;
     private String title;
     private ProjectStatus status;
     private Subject subject;
     private boolean myLike;
-    @Setter
     private List<Skill> skills;
-    @Setter
     private List<RemainedJobDto> remainedJobs;
     private boolean profitable;
     private int views;
-    @Setter
     private int likes;
-    @Setter
     private int comments;
     private String representImageUri;
+
+    @Getter
+    @Builder
+    public static class Editor {
+
+        private List<Skill> skills;
+        private List<RemainedJobDto> remainedJobs;
+        private int likes;
+        private int comments;
+
+        public static Editor fromSkills(List<Skill> skills) {
+            return Editor.builder().skills(skills).build();
+        }
+
+        public static Editor fromRemainedJobs(List<RemainedJobDto> remainedJobs) {
+            return Editor.builder().remainedJobs(remainedJobs).build();
+        }
+
+        public static Editor fromLikes(int likes) {
+            return Editor.builder().likes(likes).build();
+        }
+
+        public static Editor fromComments(int comments) {
+            return Editor.builder().comments(comments).build();
+        }
+
+        public void merge(ProjectInfo original) {
+            if (!CollectionUtils.isEmpty(skills)) {
+                original.skills = skills;
+            }
+            if (!CollectionUtils.isEmpty(remainedJobs)) {
+                original.remainedJobs = remainedJobs;
+            }
+            if (likes > 0) {
+                original.likes = likes;
+            }
+            if (comments > 0) {
+                original.comments = comments;
+            }
+        }
+    }
 }

--- a/src/test/java/com/whatpl/domain/project/model/ProjectFixture.java
+++ b/src/test/java/com/whatpl/domain/project/model/ProjectFixture.java
@@ -9,9 +9,10 @@ import java.util.List;
 
 public class ProjectFixture {
 
-    public static Project create() {
+    public static Project create(ProjectStatus status) {
         return Project.builder()
                 .title("테스트 타이틀")
+                .status(status)
                 .subject(Subject.SOCIAL_MEDIA)
                 .content("<p>테스트 콘텐츠 HTML<p>")
                 .profitable(false)
@@ -21,7 +22,7 @@ public class ProjectFixture {
     }
 
     public static Project withRecruitJobs(RecruitJob... recruitJobs) {
-        Project project = create();
+        Project project = create(ProjectStatus.RECRUITING);
         if(recruitJobs != null) {
             for (RecruitJob recruitJob : recruitJobs) {
                 project.addRecruitJob(recruitJob);
@@ -31,7 +32,7 @@ public class ProjectFixture {
     }
 
     public static Project withRecruitJobAndParticipant(List<RecruitJob> recruitJobs, List<ProjectParticipant> participant) {
-        Project project = create();
+        Project project = create(ProjectStatus.RECRUITING);
         recruitJobs.forEach(project::addRecruitJob);
         participant.forEach(project::addProjectParticipant);
         return project;

--- a/src/test/java/com/whatpl/domain/project/service/ProjectApplyServiceTest.java
+++ b/src/test/java/com/whatpl/domain/project/service/ProjectApplyServiceTest.java
@@ -50,9 +50,8 @@ class ProjectApplyServiceTest {
     @DisplayName("삭제된 프로젝트에 지원하면 실패")
     void apply_deleted_project() {
         // given
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.DELETED);
         Member writer = MemberFixture.onlyRequired();
-        project.setStatus(ProjectStatus.DELETED);
         ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
@@ -69,9 +68,8 @@ class ProjectApplyServiceTest {
     @DisplayName("모집완료된 프로젝트에 지원하면 실패")
     void apply_completed_project() {
         // given
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.COMPLETED);
         Member writer = MemberFixture.onlyRequired();
-        project.setStatus(ProjectStatus.COMPLETED);
         ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
@@ -88,10 +86,9 @@ class ProjectApplyServiceTest {
     @DisplayName("본인이 등록한 프로젝트에 지원하면 실패")
     void apply_writer_equals_applicant() {
         // given
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.RECRUITING);
         Member writer = MemberFixture.onlyRequired();
         project.addRepresentImageAndWriter(null, writer);
-        project.setStatus(ProjectStatus.RECRUITING);
         ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);
         when(projectRepository.findWithRecruitJobsById(anyLong()))
                 .thenReturn(Optional.of(project));
@@ -108,10 +105,9 @@ class ProjectApplyServiceTest {
     @DisplayName("모집직군에 지원하는 직무가 없으면 실패")
     void apply_has_not_match_job_project() {
         // given
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.RECRUITING);
         Member writer = MemberFixture.onlyRequired();
         project.addRepresentImageAndWriter(null, writer);
-        project.setStatus(ProjectStatus.RECRUITING);
         project.addRecruitJob(new RecruitJob(Job.DESIGNER, 5));
 
         ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);
@@ -131,13 +127,12 @@ class ProjectApplyServiceTest {
     void apply_full_job_project() {
         // given
         int recruitAmount = 1;
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.RECRUITING);
         Member writer = MemberFixture.onlyRequired();
         Member applicant = MemberFixture.withAll();
         ProjectParticipant participant = ProjectParticipantFixture.create(Job.BACKEND_DEVELOPER, applicant);
         project.addProjectParticipant(participant);
         project.addRepresentImageAndWriter(null, writer);
-        project.setStatus(ProjectStatus.RECRUITING);
         project.addRecruitJob(new RecruitJob(Job.BACKEND_DEVELOPER, recruitAmount));
 
         ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);
@@ -156,13 +151,12 @@ class ProjectApplyServiceTest {
     @DisplayName("이미 지원한 프로젝트에 지원하면 실패")
     void apply_duplicated_apply_project() {
         // given
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.RECRUITING);
         Member writer = MemberFixture.onlyRequired();
         Member applicant = MemberFixture.withAll();
         Apply apply = ApplyFixture.waiting(Job.BACKEND_DEVELOPER, applicant, project); // 현재상태 WAITING
         project.addApply(apply);
         project.addRepresentImageAndWriter(null, writer);
-        project.setStatus(ProjectStatus.RECRUITING);
         project.addRecruitJob(new RecruitJob(Job.BACKEND_DEVELOPER, 5));
 
         ProjectApplyRequest request = ProjectApplyRequestFixture.apply(Job.BACKEND_DEVELOPER);

--- a/src/test/java/com/whatpl/domain/project/service/ProjectCommentServiceTest.java
+++ b/src/test/java/com/whatpl/domain/project/service/ProjectCommentServiceTest.java
@@ -1,5 +1,6 @@
 package com.whatpl.domain.project.service;
 
+import com.whatpl.domain.project.model.ProjectStatus;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.domain.member.domain.Member;
@@ -38,7 +39,7 @@ class ProjectCommentServiceTest {
     @DisplayName("댓글 수정 시 요청 projectId와 댓글의 projectId가 일치하지 않을 경우 예외 발생")
     void updateProjectComment_not_match() {
         // given
-        Project project = spy(ProjectFixture.create());
+        Project project = spy(ProjectFixture.create(ProjectStatus.RECRUITING));
         when(project.getId()).thenReturn(1L);
         ProjectComment projectComment = ProjectCommentFixture.normal(project, MemberFixture.onlyRequired());
         when(projectCommentRepository.findById(anyLong())).thenReturn(Optional.of(projectComment));
@@ -53,7 +54,7 @@ class ProjectCommentServiceTest {
     @DisplayName("댓글 삭제 시 요청 projectId와 댓글의 projectId가 일치하지 않을 경우 예외 발생")
     void deleteProjectComment_not_match() {
         // given
-        Project project = spy(ProjectFixture.create());
+        Project project = spy(ProjectFixture.create(ProjectStatus.RECRUITING));
         when(project.getId()).thenReturn(1L);
         ProjectComment projectComment = ProjectCommentFixture.normal(project, MemberFixture.onlyRequired());
         when(projectCommentRepository.findById(anyLong())).thenReturn(Optional.of(projectComment));
@@ -67,7 +68,7 @@ class ProjectCommentServiceTest {
     @DisplayName("댓글 리스트 조회 시 삭제된 댓글은 '삭제된 댓글입니다.'로 표기")
     void readProjectCommentList_deleted_comment() {
         // given
-        Project project = ProjectFixture.create();
+        Project project = ProjectFixture.create(ProjectStatus.RECRUITING);
         Member writer = spy(MemberFixture.onlyRequired());
         ProjectComment projectComment = spy(ProjectCommentFixture.deleted(project, writer));
         when(writer.getId()).thenReturn(1L);

--- a/src/test/java/com/whatpl/domain/project/service/ProjectParticipantServiceTest.java
+++ b/src/test/java/com/whatpl/domain/project/service/ProjectParticipantServiceTest.java
@@ -1,5 +1,6 @@
 package com.whatpl.domain.project.service;
 
+import com.whatpl.domain.project.model.ProjectStatus;
 import com.whatpl.global.common.model.Job;
 import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.member.model.MemberFixture;
@@ -45,7 +46,7 @@ class ProjectParticipantServiceTest {
     void deleteParticipant() {
         // given
         Member participant = Mockito.spy(MemberFixture.onlyRequired());
-        Project project = Mockito.spy(ProjectFixture.create());
+        Project project = Mockito.spy(ProjectFixture.create(ProjectStatus.RECRUITING));
         ProjectParticipant projectParticipant = ProjectParticipant.builder()
                 .job(Job.BACKEND_DEVELOPER)
                 .project(project)


### PR DESCRIPTION
## 📝작업 내용

- Setter를 제거하고, 변경범위를 최소화하도록 코드를 refactoring 했습니다.
- 프로젝트 List Response 객체 (ProjectInfo) 에 적용되어 있던 Setter를 제거하고, ProjectInfo 내부에 Editor 클래스를 만들어 Editor클래스의 메서드를 통해서만 ProjectInfo 객체가 변경될 수 있도록 변경범위를 최소화 했습니다.
- Entity에 적용되어있던 연관관계를 맺기 위한 Setter를 별도의 메서드(addRelation)으로 변경했습니다.
- 이 밖에 사용되지 않던 Setter 를 모두 제거했습니다.