### PR TITLE
프로젝트 정렬조건 생성 책임 분리

### DIFF
--- a/src/main/java/com/whatpl/domain/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ProjectSearchCondition.java
@@ -1,7 +1,5 @@
 package com.whatpl.domain.project.dto;
 
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import com.whatpl.domain.project.model.ProjectStatus;
 import com.whatpl.global.common.model.Job;
 import com.whatpl.global.common.model.Skill;
@@ -10,12 +8,7 @@ import com.whatpl.global.security.domain.MemberPrincipal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Sort;
 import org.springframework.util.StringUtils;
-
-import java.util.Optional;
-
-import static com.whatpl.domain.project.domain.QProject.project;
 
 @Getter
 @Builder
@@ -43,28 +36,5 @@ public class ProjectSearchCondition {
                 this.skill == null &&
                 this.profitable == null &&
                 !StringUtils.hasText(this.keyword);
-    }
-
-    public enum OrderType {
-        LATEST {
-            @Override
-            public Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order) {
-                if (order.getProperty().equalsIgnoreCase(name())) {
-                    return Optional.of(new OrderSpecifier<>(Order.DESC, project.createdAt));
-                }
-                return Optional.empty();
-            }
-        },
-        POPULAR {
-            @Override
-            public Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order) {
-                if (order.getProperty().equalsIgnoreCase(ProjectSearchCondition.OrderType.POPULAR.name())) {
-                    return Optional.of(new OrderSpecifier<>(Order.DESC, project.views));
-                }
-                return Optional.empty();
-            }
-        };
-
-        public abstract Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order);
     }
 }

--- a/src/main/java/com/whatpl/domain/project/repository/project/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/domain/project/repository/project/ProjectQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.whatpl.domain.project.domain.*;
 import com.whatpl.domain.project.model.ProjectStatus;
 import com.whatpl.domain.project.dto.ProjectInfo;
 import com.whatpl.domain.project.dto.ProjectSearchCondition;
+import com.whatpl.domain.project.repository.project.dto.ProjectOrderType;
 import com.whatpl.global.common.model.Job;
 import com.whatpl.global.common.model.Skill;
 import com.whatpl.global.common.model.Subject;
@@ -82,10 +83,7 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
      */
     private OrderSpecifier<?>[] projectOrderBy(Pageable pageable) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
-        pageable.getSort().forEach(order -> {
-            Arrays.stream(ProjectSearchCondition.OrderType.values())
-                    .forEach(orderType -> orderType.getOrderSpecifier(order).ifPresent(orderSpecifiers::add));
-        });
+        pageable.getSort().forEach(order -> ProjectOrderType.getOrderSpecifier(order).ifPresent(orderSpecifiers::add));
         return orderSpecifiers.toArray(new OrderSpecifier[0]);
     }
 

--- a/src/main/java/com/whatpl/domain/project/repository/project/dto/ProjectOrderType.java
+++ b/src/main/java/com/whatpl/domain/project/repository/project/dto/ProjectOrderType.java
@@ -1,0 +1,53 @@
+package com.whatpl.domain.project.repository.project.dto;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.whatpl.domain.project.domain.QProject.project;
+
+@RequiredArgsConstructor
+public enum ProjectOrderType {
+    LATEST(ProjectOrderSpecifier.Latest.getInstance()),
+    POPULAR(ProjectOrderSpecifier.Popular.getInstance());
+
+    private final OrderSpecifier<? extends Comparable<?>> orderSpecifier;
+
+    public static Optional<OrderSpecifier<? extends Comparable<?>>> getOrderSpecifier(Sort.Order order) {
+        return Arrays.stream(values())
+                .filter(value -> value.name().equalsIgnoreCase(order.getProperty()))
+                .findFirst()
+                .map(orderType -> orderType.orderSpecifier);
+    }
+
+    private static class ProjectOrderSpecifier {
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        static class Latest {
+            static class LatestInstanceHolder {
+                private static final OrderSpecifier<? extends Comparable<?>> INSTANCE = new OrderSpecifier<>(Order.DESC, project.createdAt);
+            }
+
+            static OrderSpecifier<? extends Comparable<?>> getInstance() {
+                return LatestInstanceHolder.INSTANCE;
+            }
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PRIVATE)
+        static class Popular {
+            static class PopularInstanceHolder {
+                private static final OrderSpecifier<? extends Comparable<?>> INSTANCE = new OrderSpecifier<>(Order.DESC, project.views);
+            }
+
+            static OrderSpecifier<? extends Comparable<?>> getInstance() {
+                return PopularInstanceHolder.INSTANCE;
+            }
+        }
+    }
+}

--- a/src/main/java/com/whatpl/domain/project/util/ProjectCacheUtils.java
+++ b/src/main/java/com/whatpl/domain/project/util/ProjectCacheUtils.java
@@ -2,6 +2,7 @@ package com.whatpl.domain.project.util;
 
 import com.whatpl.domain.project.model.ProjectStatus;
 import com.whatpl.domain.project.dto.ProjectSearchCondition;
+import com.whatpl.domain.project.repository.project.dto.ProjectOrderType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +17,7 @@ public class ProjectCacheUtils {
     }
 
     public static boolean isCacheable(Pageable pageable, ProjectSearchCondition searchCondition) {
-        String latest = ProjectSearchCondition.OrderType.LATEST.name().toLowerCase();
+        String latest = ProjectOrderType.LATEST.name().toLowerCase();
         return pageable.getPageNumber() == 0 &&
                 (pageable.getSort().isEmpty() || pageable.getSort().getOrderFor(latest) != null) &&
                 searchCondition.isEmpty();


### PR DESCRIPTION
## 📝작업 내용

- 프로젝트 검색 조건DTO에 있던 정렬조건 생성 책임을 별도의 객체(Enum)로 분리 시켰습니다.
- 정렬조건은 매번 객체를 생성하는 방식이 아닌 Singleton으로 인스턴스를 생성해두고 가져오도록 구현했습니다.
