### PR TITLE
왓피플 리스트 API Docs 조회가 제대로 되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/whatpl/domain/whatplpople/repository/WhatplpeopleRepository.java
+++ b/src/main/java/com/whatpl/domain/whatplpople/repository/WhatplpeopleRepository.java
@@ -3,5 +3,5 @@ package com.whatpl.domain.whatplpople.repository;
 import com.whatpl.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface WhatplpeopleRepository extends WhatplepeopleQueryRepository {
+public interface WhatplpeopleRepository extends JpaRepository<Member,Long>, WhatplepeopleQueryRepository {
 }

--- a/src/test/java/com/whatpl/domain/whatplpople/controller/WhatplpeopleControllerTest.java
+++ b/src/test/java/com/whatpl/domain/whatplpople/controller/WhatplpeopleControllerTest.java
@@ -78,7 +78,7 @@ class WhatplpeopleControllerTest extends BaseSecurityWebMvcTest {
                 jsonPath("$.list[*].career").value(whatplpeopleDto.getCareer().getValue()),
                 jsonPath("$.list[*].memberSkills").exists(),
                 jsonPath("$.list[*].memberSubjects").exists()
-        ).andDo(print()).andDo(document("search-me-whatplpeople",
+        ).andDo(print()).andDo(document("me-whatplpeoples",
                 resourceDetails().tag(ApiDocTag.WHATPLPEOPLE.getTag())
                         .summary("내가 찾는 피플")
                         .description("내가 찾는 피플"),
@@ -144,10 +144,10 @@ class WhatplpeopleControllerTest extends BaseSecurityWebMvcTest {
                 jsonPath("$.list[*].career").value(whatplpeopleDto.getCareer().getValue()),
                 jsonPath("$.list[*].memberSkills").exists(),
                 jsonPath("$.list[*].memberSubjects").exists()
-        ).andDo(print()).andDo(document("search-me-whatplpeople",
+        ).andDo(print()).andDo(document("whatplpeoples-me",
                 resourceDetails().tag(ApiDocTag.WHATPLPEOPLE.getTag())
-                        .summary("내가 찾는 피플")
-                        .description("내가 찾는 피플"),
+                        .summary("나를 찾는 피플")
+                        .description("나를 찾는 피플"),
                 queryParameters(
                         parameterWithName("page").description("페이지 번호"),
                         parameterWithName("size").description("페이지 사이즈"),
@@ -209,10 +209,10 @@ class WhatplpeopleControllerTest extends BaseSecurityWebMvcTest {
                 jsonPath("$.list[*].career").value(whatplpeopleDto.getCareer().getValue()),
                 jsonPath("$.list[*].memberSkills").exists(),
                 jsonPath("$.list[*].memberSubjects").exists()
-        ).andDo(print()).andDo(document("search-me-whatplpeople",
+        ).andDo(print()).andDo(document("whatplpeoples-all",
                 resourceDetails().tag(ApiDocTag.WHATPLPEOPLE.getTag())
-                        .summary("내가 찾는 피플")
-                        .description("내가 찾는 피플"),
+                        .summary("모든 왓피플")
+                        .description("모든 왓피플"),
                 queryParameters(
                         parameterWithName("page").description("페이지 번호"),
                         parameterWithName("size").description("페이지 사이즈"),


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 #47 

## 📝작업 내용

> API Docs의 document 부분의 네이밍이 겹치는 문제 수정
