### PR TITLE
멤버 프로필 수정 및 조회, 이미지 조회 Url Parser

### DIFF
--- a/src/main/java/com/whatpl/domain/attachment/controller/AttachmentController.java
+++ b/src/main/java/com/whatpl/domain/attachment/controller/AttachmentController.java
@@ -26,7 +26,7 @@ public class AttachmentController {
 
     @PostMapping("/attachments")
     public ResponseEntity<UploadResponse> upload(@ValidFile @RequestPart("file") MultipartFile multipartFile) {
-        long id = attachmentService.upload(multipartFile);
+        long id = attachmentService.uploadAndSave(multipartFile);
         return ResponseEntity.status(HttpStatus.CREATED).body(new UploadResponse(id));
     }
 

--- a/src/main/java/com/whatpl/domain/attachment/controller/MemberAttachmentController.java
+++ b/src/main/java/com/whatpl/domain/attachment/controller/MemberAttachmentController.java
@@ -1,0 +1,38 @@
+package com.whatpl.domain.attachment.controller;
+
+import com.whatpl.domain.attachment.dto.ResourceDto;
+import com.whatpl.domain.member.service.MemberPictureService;
+import com.whatpl.domain.member.service.MemberPortfolioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/attachments")
+@RequiredArgsConstructor
+public class MemberAttachmentController {
+
+    private final MemberPortfolioService memberPortfolioService;
+    private final MemberPictureService memberPictureService;
+
+    @GetMapping("/portfolios/{portfolioId}")
+    public ResponseEntity<Resource> portfolio(@PathVariable Long portfolioId) {
+        ResourceDto resourceDto = memberPortfolioService.readPortfolio(portfolioId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, resourceDto.getMimeType())
+                .body(resourceDto.getResource());
+    }
+
+    @GetMapping("/pictures/{pictureId}")
+    public ResponseEntity<Resource> picture(@PathVariable Long pictureId) {
+        ResourceDto resourceDto = memberPictureService.readPicture(pictureId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, resourceDto.getMimeType())
+                .body(resourceDto.getResource());
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/controller/ProjectAttachmentController.java
+++ b/src/main/java/com/whatpl/domain/attachment/controller/ProjectAttachmentController.java
@@ -1,0 +1,28 @@
+package com.whatpl.domain.attachment.controller;
+
+import com.whatpl.domain.attachment.dto.ResourceDto;
+import com.whatpl.domain.project.service.ProjectReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/attachments")
+@RequiredArgsConstructor
+public class ProjectAttachmentController {
+
+    private final ProjectReadService projectReadService;
+
+    @GetMapping("/projects/represent-images/{representImageId}")
+    public ResponseEntity<Resource> portfolio(@PathVariable Long representImageId) {
+        ResourceDto resourceDto = projectReadService.readRepresentImage(representImageId);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, resourceDto.getMimeType())
+                .body(resourceDto.getResource());
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParseDelegator.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParseDelegator.java
@@ -1,0 +1,22 @@
+package com.whatpl.domain.attachment.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AttachmentUrlParseDelegator {
+
+    private final List<AttachmentUrlParser> attachmentUrlParsers;
+
+    public String parseUrl(AttachmentUrlParseType type, Long id) {
+        for (AttachmentUrlParser attachmentUrlParser : attachmentUrlParsers) {
+            if (attachmentUrlParser.supports(type)) {
+                return attachmentUrlParser.parseUrl(id);
+            }
+        }
+        throw new IllegalStateException("일치하는 UrlParser가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParseType.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParseType.java
@@ -2,5 +2,6 @@ package com.whatpl.domain.attachment.domain;
 
 public enum AttachmentUrlParseType {
     MEMBER_PORTFOLIO,
-    MEMBER_PICTURE
+    MEMBER_PICTURE,
+    PROJECT_REPRESENT_IMAGE
 }

--- a/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParseType.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParseType.java
@@ -1,0 +1,6 @@
+package com.whatpl.domain.attachment.domain;
+
+public enum AttachmentUrlParseType {
+    MEMBER_PORTFOLIO,
+    MEMBER_PICTURE
+}

--- a/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParser.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/AttachmentUrlParser.java
@@ -1,0 +1,6 @@
+package com.whatpl.domain.attachment.domain;
+
+public interface AttachmentUrlParser {
+    boolean supports(AttachmentUrlParseType type);
+    String parseUrl(Long id);
+}

--- a/src/main/java/com/whatpl/domain/attachment/domain/MemberPictureUrlParser.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/MemberPictureUrlParser.java
@@ -1,0 +1,26 @@
+package com.whatpl.domain.attachment.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class MemberPictureUrlParser implements AttachmentUrlParser {
+
+    @Value("${server-url}")
+    private String serverUrl;
+
+    @Override
+    public boolean supports(AttachmentUrlParseType type) {
+        return Objects.equals(type, AttachmentUrlParseType.MEMBER_PICTURE);
+    }
+
+    @Override
+    public String parseUrl(Long id) {
+        if (id == null) return null;
+        return String.format("%s/attachments/pictures/%d", serverUrl, id);
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/domain/MemberPortfolioUrlParser.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/MemberPortfolioUrlParser.java
@@ -1,0 +1,26 @@
+package com.whatpl.domain.attachment.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class MemberPortfolioUrlParser implements AttachmentUrlParser {
+
+    @Value("${server-url}")
+    private String serverUrl;
+
+    @Override
+    public boolean supports(AttachmentUrlParseType type) {
+        return Objects.equals(type, AttachmentUrlParseType.MEMBER_PORTFOLIO);
+    }
+
+    @Override
+    public String parseUrl(Long id) {
+        if (id == null) return null;
+        return String.format("%s/attachments/portfolios/%d", serverUrl, id);
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/domain/ProjectRepresentImageUrlParser.java
+++ b/src/main/java/com/whatpl/domain/attachment/domain/ProjectRepresentImageUrlParser.java
@@ -1,0 +1,26 @@
+package com.whatpl.domain.attachment.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectRepresentImageUrlParser implements AttachmentUrlParser {
+
+    @Value("${server-url}")
+    private String serverUrl;
+
+    @Override
+    public boolean supports(AttachmentUrlParseType type) {
+        return Objects.equals(type, AttachmentUrlParseType.PROJECT_REPRESENT_IMAGE);
+    }
+
+    @Override
+    public String parseUrl(Long representImageId) {
+        if (representImageId == null) return String.format("%s/images/project", serverUrl);
+        return String.format("%s/attachments/projects/represent-images/%d", serverUrl, representImageId);
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/event/AttachmentDeleteEvent.java
+++ b/src/main/java/com/whatpl/domain/attachment/event/AttachmentDeleteEvent.java
@@ -1,0 +1,15 @@
+package com.whatpl.domain.attachment.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AttachmentDeleteEvent {
+
+    private final String storedName;
+
+    public static AttachmentDeleteEvent from(final String storedName) {
+        return new AttachmentDeleteEvent(storedName);
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/event/handler/AttachmentEventHandler.java
+++ b/src/main/java/com/whatpl/domain/attachment/event/handler/AttachmentEventHandler.java
@@ -1,0 +1,20 @@
+package com.whatpl.domain.attachment.event.handler;
+
+import com.whatpl.domain.attachment.event.AttachmentDeleteEvent;
+import com.whatpl.external.upload.FileUploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class AttachmentEventHandler {
+
+    private final FileUploader fileUploader;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDelete(AttachmentDeleteEvent event) {
+        fileUploader.delete(event.getStoredName());
+    }
+}

--- a/src/main/java/com/whatpl/domain/attachment/service/AttachmentService.java
+++ b/src/main/java/com/whatpl/domain/attachment/service/AttachmentService.java
@@ -21,14 +21,19 @@ public class AttachmentService {
     private final FileUploader fileUploader;
 
     @Transactional
-    public Long upload(MultipartFile multipartFile) {
+    public Attachment upload(MultipartFile multipartFile) {
         String storedName = fileUploader.upload(multipartFile);
         String mimeType = FileUtils.extractMimeType(multipartFile);
-        Attachment attachment = Attachment.builder()
+        return Attachment.builder()
                 .fileName(multipartFile.getOriginalFilename())
                 .storedName(storedName)
                 .mimeType(mimeType)
                 .build();
+    }
+
+    @Transactional
+    public Long uploadAndSave(MultipartFile multipartFile) {
+        Attachment attachment = upload(multipartFile);
         Attachment savedAttachment = attachmentRepository.save(attachment);
         return savedAttachment.getId();
     }

--- a/src/main/java/com/whatpl/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/whatpl/domain/chat/dto/ChatMessageDto.java
@@ -6,24 +6,20 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatMessageDto implements SliceElement {
     private long messageId;
     private String content;
     private long senderId;
     private String senderNickname;
-    private String senderProfileImgUri; // TODO 보낸 사람 프로필 이미지 URI
+    private Long senderPictureId;
+    private String senderPictureUrl;
     private LocalDateTime sendAt;
     private LocalDateTime readAt;
 
-    @Builder
-    public ChatMessageDto(long messageId, String content, long senderId, String senderNickname, String senderProfileImgUri, LocalDateTime sendAt, LocalDateTime readAt) {
-        this.messageId = messageId;
-        this.content = content;
-        this.senderId = senderId;
-        this.senderNickname = senderNickname;
-        this.senderProfileImgUri = senderProfileImgUri;
-        this.sendAt = sendAt;
-        this.readAt = readAt;
+    public void assignSenderPictureUrl(String senderPictureUrl) {
+        this.senderPictureUrl = senderPictureUrl;
     }
 }

--- a/src/main/java/com/whatpl/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/whatpl/domain/chat/dto/ChatRoomResponse.java
@@ -21,8 +21,13 @@ public class ChatRoomResponse implements SliceElement {
     private String projectTitle;
     private long opponentId;
     private String opponentNickname;
-    private String opponentProfileImgUri; // TODO 상대방 프로필 이미지 URI
+    private Long opponentPictureId;
+    private String opponentPictureUrl;
     private String lastMessageContent;
     private LocalDateTime lastMessageTime;
     private boolean lastMessageRead;
+
+    public void assignOpponentPictureUrl(String opponentPictureUrl) {
+        this.opponentPictureUrl = opponentPictureUrl;
+    }
 }

--- a/src/main/java/com/whatpl/domain/chat/repository/message/ChatMessageQueryRepositoryImpl.java
+++ b/src/main/java/com/whatpl/domain/chat/repository/message/ChatMessageQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.whatpl.domain.chat.repository.message;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.whatpl.domain.attachment.domain.QAttachment;
 import com.whatpl.domain.chat.dto.ChatMessageDto;
 import com.whatpl.domain.member.domain.QMember;
 import com.whatpl.global.util.PaginationUtils;
@@ -23,16 +24,19 @@ public class ChatMessageQueryRepositoryImpl implements ChatMessageQueryRepositor
     public Slice<ChatMessageDto> findMessagesByChatRoomId(Long chatRoomId, Pageable pageable) {
         int pageSize = pageable.getPageSize();
         QMember sender = new QMember("sender");
+        QAttachment senderPicture = new QAttachment("senderPicture");
         List<ChatMessageDto> list = queryFactory.select(Projections.fields(ChatMessageDto.class,
                         chatMessage.id.as("messageId"),
                         chatMessage.content.as("content"),
                         sender.id.as("senderId"),
                         sender.nickname.as("senderNickname"),
+                        senderPicture.id.as("senderPictureId"),
                         chatMessage.createdAt.as("sendAt"),
                         chatMessage.readAt.as("readAt")
                 ))
                 .from(chatMessage)
                 .leftJoin(chatMessage.sender, sender)
+                .leftJoin(chatMessage.sender.picture, senderPicture)
                 .where(chatMessage.chatRoom.id.eq(chatRoomId))
                 .orderBy(chatMessage.createdAt.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/whatpl/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/whatpl/domain/chat/service/ChatRoomService.java
@@ -1,5 +1,7 @@
 package com.whatpl.domain.chat.service;
 
+import com.whatpl.domain.attachment.domain.AttachmentUrlParseDelegator;
+import com.whatpl.domain.attachment.domain.AttachmentUrlParseType;
 import com.whatpl.domain.chat.domain.ChatRoom;
 import com.whatpl.domain.chat.dto.ChatRoomResponse;
 import com.whatpl.domain.chat.repository.room.ChatRoomRepository;
@@ -21,6 +23,7 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageService chatMessageService;
+    private final AttachmentUrlParseDelegator attachmentUrlParseDelegator;
 
     @Transactional
     public long createChatRoom(final Apply apply, final String content) {
@@ -37,6 +40,13 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public Slice<ChatRoomResponse> readChatRooms(final Pageable pageable, final Long memberId) {
         List<ChatRoomResponse> chatRooms = chatRoomRepository.findChatRooms(pageable, memberId);
+        chatRooms.forEach(chatRoom -> {
+            String opponentPictureId = attachmentUrlParseDelegator.parseUrl(
+                    AttachmentUrlParseType.MEMBER_PICTURE,
+                    chatRoom.getOpponentPictureId()
+            );
+            chatRoom.assignOpponentPictureUrl(opponentPictureId);
+        });
         return new SliceImpl<>(chatRooms, pageable, PaginationUtils.hasNext(chatRooms, pageable.getPageSize()));
     }
 }

--- a/src/main/java/com/whatpl/domain/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/domain/member/controller/MemberController.java
@@ -50,8 +50,11 @@ public class MemberController {
     @PreAuthorize("hasPermission(#memberId, 'MEMBER', 'UPDATE')")
     @PutMapping("/{memberId}")
     public ResponseEntity<Void> updateProfile(@PathVariable Long memberId,
-                                              @Valid @RequestBody ProfileUpdateRequest request) {
-        memberProfileService.updateProfile(request, memberId);
+                                              @Valid @RequestPart ProfileUpdateRequest info,
+                                              @Size(max = 5, message = "포트폴리오는 최대 5개 첨부 가능합니다.")
+                                              @ValidFileList(message = "포트폴리오에 허용된 확장자가 아닙니다. [jpg, jpeg, png, gif, pdf]")
+                                              @RequestPart(required = false) List<MultipartFile> portfolios) {
+        memberProfileService.updateProfile(info, portfolios, memberId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/whatpl/domain/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.whatpl.domain.member.dto.*;
 import com.whatpl.domain.member.service.MemberProfileService;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.global.web.validator.ValidFileList;
+import com.whatpl.global.web.validator.ValidPicture;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
@@ -62,5 +63,13 @@ public class MemberController {
     public ResponseEntity<MemberProfileResponse> readProfile(@PathVariable Long memberId) {
         MemberProfileResponse memberProfileResponse = memberProfileService.readProfile(memberId);
         return ResponseEntity.ok(memberProfileResponse);
+    }
+
+    @PreAuthorize("hasPermission(#memberId, 'MEMBER', 'UPDATE')")
+    @PutMapping("/{memberId}/picture")
+    public ResponseEntity<Void> updatePicture(@PathVariable Long memberId,
+                                              @ValidPicture @RequestPart("picture") MultipartFile multipartFile) {
+        memberProfileService.updatePicture(memberId, multipartFile);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whatpl/domain/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/domain/member/controller/MemberController.java
@@ -1,12 +1,9 @@
 package com.whatpl.domain.member.controller;
 
+import com.whatpl.domain.member.dto.*;
+import com.whatpl.domain.member.service.MemberProfileService;
 import com.whatpl.global.security.domain.MemberPrincipal;
 import com.whatpl.global.web.validator.ValidFileList;
-import com.whatpl.domain.member.dto.NicknameDuplRequest;
-import com.whatpl.domain.member.dto.NicknameDuplResponse;
-import com.whatpl.domain.member.dto.ProfileOptionalRequest;
-import com.whatpl.domain.member.dto.ProfileRequiredRequest;
-import com.whatpl.domain.member.service.MemberProfileService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +43,15 @@ public class MemberController {
                                          @RequestPart(required = false) List<MultipartFile> portfolios,
                                          @AuthenticationPrincipal MemberPrincipal principal) {
         memberProfileService.updateOptionalProfile(info, portfolios, principal.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/my-profile")
+    public ResponseEntity<Void> updateProfile(
+            @Valid @RequestBody ProfileUpdateRequest request,
+            @AuthenticationPrincipal MemberPrincipal principal
+    ) {
+        memberProfileService.updateProfile(request, principal.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whatpl/domain/member/controller/MemberController.java
+++ b/src/main/java/com/whatpl/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -46,12 +47,17 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/my-profile")
-    public ResponseEntity<Void> updateProfile(
-            @Valid @RequestBody ProfileUpdateRequest request,
-            @AuthenticationPrincipal MemberPrincipal principal
-    ) {
-        memberProfileService.updateProfile(request, principal.getId());
+    @PreAuthorize("hasPermission(#memberId, 'MEMBER', 'UPDATE')")
+    @PutMapping("/{memberId}")
+    public ResponseEntity<Void> updateProfile(@PathVariable Long memberId,
+                                              @Valid @RequestBody ProfileUpdateRequest request) {
+        memberProfileService.updateProfile(request, memberId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberProfileResponse> readProfile(@PathVariable Long memberId) {
+        MemberProfileResponse memberProfileResponse = memberProfileService.readProfile(memberId);
+        return ResponseEntity.ok(memberProfileResponse);
     }
 }

--- a/src/main/java/com/whatpl/domain/member/controller/MemberProjectController.java
+++ b/src/main/java/com/whatpl/domain/member/controller/MemberProjectController.java
@@ -1,0 +1,25 @@
+package com.whatpl.domain.member.controller;
+
+import com.whatpl.domain.member.service.MemberProjectService;
+import com.whatpl.domain.project.dto.ParticipatedProject;
+import com.whatpl.domain.project.dto.ParticipatedProjectResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberProjectController {
+
+    private final MemberProjectService memberProjectService;
+
+    @GetMapping("/members/{memberId}/projects/participated")
+    public ResponseEntity<ParticipatedProjectResponse> readParticipatedProject(@PathVariable Long memberId) {
+        List<ParticipatedProject> participatedProjects = memberProjectService.readParticipatedProjects(memberId);
+        return ResponseEntity.ok(ParticipatedProjectResponse.from(participatedProjects));
+    }
+}

--- a/src/main/java/com/whatpl/domain/member/controller/MemberProjectController.java
+++ b/src/main/java/com/whatpl/domain/member/controller/MemberProjectController.java
@@ -3,6 +3,8 @@ package com.whatpl.domain.member.controller;
 import com.whatpl.domain.member.service.MemberProjectService;
 import com.whatpl.domain.project.dto.ParticipatedProject;
 import com.whatpl.domain.project.dto.ParticipatedProjectResponse;
+import com.whatpl.domain.project.dto.ProjectInfo;
+import com.whatpl.domain.project.dto.RecruitedProjectResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,5 +23,11 @@ public class MemberProjectController {
     public ResponseEntity<ParticipatedProjectResponse> readParticipatedProject(@PathVariable Long memberId) {
         List<ParticipatedProject> participatedProjects = memberProjectService.readParticipatedProjects(memberId);
         return ResponseEntity.ok(ParticipatedProjectResponse.from(participatedProjects));
+    }
+
+    @GetMapping("/members/{memberId}/projects/recruited")
+    public ResponseEntity<RecruitedProjectResponse> readRecruitedProject(@PathVariable Long memberId) {
+        List<ProjectInfo> recruitedProjects = memberProjectService.readRecruitedProjects(memberId);
+        return ResponseEntity.ok(RecruitedProjectResponse.from(recruitedProjects));
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/Member.java
+++ b/src/main/java/com/whatpl/domain/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.whatpl.domain.member.domain;
 
+import com.whatpl.domain.attachment.domain.Attachment;
 import com.whatpl.global.common.model.BaseTimeEntity;
 import com.whatpl.global.common.model.*;
 import com.whatpl.global.exception.BizException;
@@ -44,15 +45,23 @@ public class Member extends BaseTimeEntity {
 
     private Boolean profileOpen;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "picture_id")
+    private Attachment picture;
+
+    @OrderBy("id")
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MemberSkill> memberSkills = new LinkedHashSet<>();
 
+    @OrderBy("id")
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MemberSubject> memberSubjects = new LinkedHashSet<>();
 
+    @OrderBy("id")
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MemberReference> memberReferences = new LinkedHashSet<>();
 
+    @OrderBy("id")
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MemberPortfolio> memberPortfolios = new LinkedHashSet<>();
 
@@ -112,6 +121,10 @@ public class Member extends BaseTimeEntity {
         }
         this.memberPortfolios.add(memberPortfolio);
         memberPortfolio.addRelation(this);
+    }
+
+    public void modifyPicture(Attachment picture) {
+        this.picture = picture;
     }
 
     //==비즈니스 로직==//

--- a/src/main/java/com/whatpl/domain/member/domain/Member.java
+++ b/src/main/java/com/whatpl/domain/member/domain/Member.java
@@ -11,6 +11,7 @@ import lombok.*;
 import org.springframework.util.CollectionUtils;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -53,7 +54,7 @@ public class Member extends BaseTimeEntity {
     private Set<MemberReference> memberReferences = new LinkedHashSet<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberPortfolio> memberPortfolios = new LinkedList<>();
+    private Set<MemberPortfolio> memberPortfolios = new LinkedHashSet<>();
 
     @Builder
     public Member(SocialType socialType, String socialId, String nickname, MemberStatus status,
@@ -114,6 +115,7 @@ public class Member extends BaseTimeEntity {
     }
 
     //==비즈니스 로직==//
+
     /**
      * 필수 정보 입력
      */
@@ -200,5 +202,17 @@ public class Member extends BaseTimeEntity {
         modifyMemberSubject(subjects);
         modifyMemberReference(references);
         modifyMemberSkills(skills);
+    }
+
+    public List<MemberPortfolio> deletePortfolios(List<Long> deletePortfolioIds) {
+        if (CollectionUtils.isEmpty(deletePortfolioIds) || CollectionUtils.isEmpty(getMemberPortfolios())) {
+            return Collections.emptyList();
+        }
+        Set<MemberPortfolio> deleteList = getMemberPortfolios().stream()
+                .filter(memberPortfolio -> deletePortfolioIds.stream()
+                        .anyMatch(deleteId -> deleteId.equals(memberPortfolio.getId())))
+                .collect(Collectors.toSet());
+        getMemberPortfolios().removeAll(deleteList);
+        return deleteList.stream().toList();
     }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/Member.java
+++ b/src/main/java/com/whatpl/domain/member/domain/Member.java
@@ -176,4 +176,29 @@ public class Member extends BaseTimeEntity {
     public void modifyWorkTime(@NonNull WorkTime workTime) {
         this.workTime = workTime;
     }
+
+    public MemberEditor.MemberEditorBuilder toEditor() {
+        return MemberEditor.builder()
+                .nickname(nickname)
+                .job(job)
+                .career(career)
+                .profileOpen(profileOpen)
+                .workTime(workTime);
+    }
+
+    public void updateProfile(
+            MemberEditor editor,
+            Set<Subject> subjects,
+            Set<String> references,
+            Set<Skill> skills
+    ) {
+        this.nickname = editor.getNickname();
+        this.job = editor.getJob();
+        this.career = editor.getCareer();
+        this.workTime = editor.getWorkTime();
+        this.profileOpen = editor.isProfileOpen();
+        modifyMemberSubject(subjects);
+        modifyMemberReference(references);
+        modifyMemberSkills(skills);
+    }
 }

--- a/src/main/java/com/whatpl/domain/member/domain/MemberEditor.java
+++ b/src/main/java/com/whatpl/domain/member/domain/MemberEditor.java
@@ -1,0 +1,27 @@
+package com.whatpl.domain.member.domain;
+
+import com.whatpl.global.common.model.Career;
+import com.whatpl.global.common.model.Job;
+import com.whatpl.global.common.model.WorkTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberEditor {
+
+    private final String nickname;
+    private final Job job;
+    private final Career career;
+    private final boolean profileOpen;
+    private final WorkTime workTime;
+
+    @Builder
+
+    public MemberEditor(String nickname, Job job, Career career, boolean profileOpen, WorkTime workTime) {
+        this.nickname = nickname;
+        this.job = job;
+        this.career = career;
+        this.profileOpen = profileOpen;
+        this.workTime = workTime;
+    }
+}

--- a/src/main/java/com/whatpl/domain/member/domain/MemberPortfolio.java
+++ b/src/main/java/com/whatpl/domain/member/domain/MemberPortfolio.java
@@ -16,7 +16,7 @@ public class MemberPortfolio extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "attachment_id")

--- a/src/main/java/com/whatpl/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/whatpl/domain/member/dto/MemberProfileResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,8 +17,9 @@ public class MemberProfileResponse {
     private final Career career;
     private final WorkTime workTime;
     private final Boolean profileOpen;
-    private final Set<Skill> skills;
-    private final Set<Subject> subjects;
-    private final Set<String> references;
-    private final Set<Long> portfolioIds;
+    private final List<Skill> skills;
+    private final List<Subject> subjects;
+    private final List<String> references;
+    private final List<String> portfolioUrls;
+    private final String pictureUrl;
 }

--- a/src/main/java/com/whatpl/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/whatpl/domain/member/dto/MemberProfileResponse.java
@@ -1,0 +1,24 @@
+package com.whatpl.domain.member.dto;
+
+import com.whatpl.global.common.model.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class MemberProfileResponse {
+
+    private final String nickname;
+    private final Job job;
+    private final Career career;
+    private final WorkTime workTime;
+    private final Boolean profileOpen;
+    private final Set<Skill> skills;
+    private final Set<Subject> subjects;
+    private final Set<String> references;
+    private final Set<Long> portfolioIds;
+}

--- a/src/main/java/com/whatpl/domain/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/whatpl/domain/member/dto/ProfileUpdateRequest.java
@@ -1,0 +1,42 @@
+package com.whatpl.domain.member.dto;
+
+import com.whatpl.global.common.model.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProfileUpdateRequest {
+
+    @NotEmpty(message = "닉네임은 필수 입력 항목입니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,8}$", message = "닉네임은 특수문자를 제외한 2~8자리여야 합니다.")
+    private String nickname;
+
+    @NotNull(message = "직무는 필수 입력 항목입니다.")
+    private Job job;
+
+    @NotNull(message = "경력은 필수 입력 항목입니다.")
+    private Career career;
+
+    @NotNull(message = "기술스택은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 10, message = "기술스택은 1 ~ 10개 입력 가능합니다.")
+    private Set<Skill> skills;
+
+    private boolean profileOpen;
+
+    @Size(max = 5, message = "관심주제는 최대 6개 입력 가능합니다.")
+    private Set<Subject> subjects;
+
+    @Size(max = 5, message = "참고링크는 최대 5개 첨부 가능합니다.")
+    private Set<String> references;
+
+    private WorkTime workTime;
+}

--- a/src/main/java/com/whatpl/domain/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/whatpl/domain/member/dto/ProfileUpdateRequest.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -39,4 +40,6 @@ public class ProfileUpdateRequest {
     private Set<String> references;
 
     private WorkTime workTime;
+
+    private List<Long> deletePortfolioIds;
 }

--- a/src/main/java/com/whatpl/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/whatpl/domain/member/mapper/MemberMapper.java
@@ -38,6 +38,7 @@ public class MemberMapper {
     }
 
     private String getBuildPictureUrl(Member member) {
-        return attachmentUrlParseDelegator.parseUrl(AttachmentUrlParseType.MEMBER_PICTURE, member.getPicture().getId());
+        Long pictureId = member.getPicture() == null ? null : member.getPicture().getId();
+        return attachmentUrlParseDelegator.parseUrl(AttachmentUrlParseType.MEMBER_PICTURE, pictureId);
     }
 }

--- a/src/main/java/com/whatpl/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/whatpl/domain/member/mapper/MemberMapper.java
@@ -1,0 +1,26 @@
+package com.whatpl.domain.member.mapper;
+
+import com.whatpl.domain.member.domain.*;
+import com.whatpl.domain.member.dto.MemberProfileResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberMapper {
+
+    public static MemberProfileResponse toMemberProfileResponse(Member member) {
+        return MemberProfileResponse.builder()
+                .nickname(member.getNickname())
+                .job(member.getJob())
+                .career(member.getCareer())
+                .profileOpen(member.getProfileOpen())
+                .workTime(member.getWorkTime())
+                .skills(member.getMemberSkills().stream().map(MemberSkill::getSkill).collect(Collectors.toSet()))
+                .subjects(member.getMemberSubjects().stream().map(MemberSubject::getSubject).collect(Collectors.toSet()))
+                .references(member.getMemberReferences().stream().map(MemberReference::getReference).collect(Collectors.toSet()))
+                .portfolioIds(member.getMemberPortfolios().stream().map(MemberPortfolio::getId).collect(Collectors.toSet()))
+                .build();
+    }
+}

--- a/src/main/java/com/whatpl/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/whatpl/domain/member/mapper/MemberMapper.java
@@ -1,26 +1,43 @@
 package com.whatpl.domain.member.mapper;
 
+import com.whatpl.domain.attachment.domain.AttachmentUrlParseDelegator;
+import com.whatpl.domain.attachment.domain.AttachmentUrlParseType;
 import com.whatpl.domain.member.domain.*;
 import com.whatpl.domain.member.dto.MemberProfileResponse;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-import java.util.stream.Collectors;
+import java.util.List;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Component
+@RequiredArgsConstructor
 public class MemberMapper {
 
-    public static MemberProfileResponse toMemberProfileResponse(Member member) {
+    private final AttachmentUrlParseDelegator attachmentUrlParseDelegator;
+
+    public MemberProfileResponse toMemberProfileResponse(Member member) {
         return MemberProfileResponse.builder()
                 .nickname(member.getNickname())
                 .job(member.getJob())
                 .career(member.getCareer())
                 .profileOpen(member.getProfileOpen())
                 .workTime(member.getWorkTime())
-                .skills(member.getMemberSkills().stream().map(MemberSkill::getSkill).collect(Collectors.toSet()))
-                .subjects(member.getMemberSubjects().stream().map(MemberSubject::getSubject).collect(Collectors.toSet()))
-                .references(member.getMemberReferences().stream().map(MemberReference::getReference).collect(Collectors.toSet()))
-                .portfolioIds(member.getMemberPortfolios().stream().map(MemberPortfolio::getId).collect(Collectors.toSet()))
+                .skills(member.getMemberSkills().stream().map(MemberSkill::getSkill).toList())
+                .subjects(member.getMemberSubjects().stream().map(MemberSubject::getSubject).toList())
+                .references(member.getMemberReferences().stream().map(MemberReference::getReference).toList())
+                .portfolioUrls(buildPortfolioUrl(member))
+                .pictureUrl(getBuildPictureUrl(member))
                 .build();
+    }
+
+    private List<String> buildPortfolioUrl(Member member) {
+        return member.getMemberPortfolios().stream()
+                .map(MemberPortfolio::getId)
+                .map(portfolioId -> attachmentUrlParseDelegator.parseUrl(AttachmentUrlParseType.MEMBER_PORTFOLIO, portfolioId))
+                .toList();
+    }
+
+    private String getBuildPictureUrl(Member member) {
+        return attachmentUrlParseDelegator.parseUrl(AttachmentUrlParseType.MEMBER_PICTURE, member.getPicture().getId());
     }
 }

--- a/src/main/java/com/whatpl/domain/member/repository/MemberPortfolioRepository.java
+++ b/src/main/java/com/whatpl/domain/member/repository/MemberPortfolioRepository.java
@@ -1,0 +1,13 @@
+package com.whatpl.domain.member.repository;
+
+import com.whatpl.domain.member.domain.MemberPortfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface MemberPortfolioRepository extends JpaRepository<MemberPortfolio, Long> {
+
+    @Query("select p from MemberPortfolio p left join fetch p.attachment where p.id = :id")
+    Optional<MemberPortfolio> findByIdWithAttachment(Long id);
+}

--- a/src/main/java/com/whatpl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/whatpl/domain/member/repository/MemberRepository.java
@@ -2,9 +2,12 @@ package com.whatpl.domain.member.repository;
 
 import com.whatpl.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository{
     Optional<Member> findByNickname(String nickname);
+    @Query("select m from Member m left join fetch m.picture where m.picture.id = :pictureId")
+    Optional<Member> findByPictureId(Long pictureId);
 }

--- a/src/main/java/com/whatpl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/whatpl/domain/member/repository/MemberRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository{
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryRepository {
+
     Optional<Member> findByNickname(String nickname);
+
     @Query("select m from Member m left join fetch m.picture where m.picture.id = :pictureId")
     Optional<Member> findByPictureId(Long pictureId);
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberPictureService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberPictureService.java
@@ -1,0 +1,42 @@
+package com.whatpl.domain.member.service;
+
+import com.whatpl.domain.attachment.domain.Attachment;
+import com.whatpl.domain.attachment.dto.ResourceDto;
+import com.whatpl.domain.attachment.event.AttachmentDeleteEvent;
+import com.whatpl.domain.attachment.service.AttachmentService;
+import com.whatpl.domain.member.domain.Member;
+import com.whatpl.domain.member.repository.MemberRepository;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class MemberPictureService {
+
+    private final AttachmentService attachmentService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void modifyPicture(Member member, MultipartFile picture) {
+        Attachment newPicture = attachmentService.upload(picture);
+        Attachment oldPicture = member.getPicture();
+        member.modifyPicture(newPicture);
+        if(oldPicture != null) {
+            eventPublisher.publishEvent(AttachmentDeleteEvent.from(oldPicture.getStoredName()));
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public ResourceDto readPicture(Long pictureId) {
+        Member member = memberRepository.findByPictureId(pictureId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_DATA));
+        Attachment attachment = member.getPicture();
+        return attachmentService.download(attachment.getId());
+    }
+}

--- a/src/main/java/com/whatpl/domain/member/service/MemberPortfolioService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberPortfolioService.java
@@ -1,9 +1,13 @@
 package com.whatpl.domain.member.service;
 
 import com.whatpl.domain.attachment.domain.Attachment;
+import com.whatpl.domain.attachment.dto.ResourceDto;
 import com.whatpl.domain.attachment.service.AttachmentService;
 import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.member.domain.MemberPortfolio;
+import com.whatpl.domain.member.repository.MemberPortfolioRepository;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +21,7 @@ import java.util.List;
 public class MemberPortfolioService {
 
     private final AttachmentService attachmentService;
+    private final MemberPortfolioRepository memberPortfolioRepository;
 
     @Transactional
     public void uploadPortfolio(Member member, List<MultipartFile> portfolios) {
@@ -29,5 +34,13 @@ public class MemberPortfolioService {
                     MemberPortfolio memberPortfolio = new MemberPortfolio(attachment);
                     member.addMemberPortfolio(memberPortfolio);
                 });
+    }
+
+    @Transactional(readOnly = true)
+    public ResourceDto readPortfolio(Long portfolioId) {
+        MemberPortfolio memberPortfolio = memberPortfolioRepository.findByIdWithAttachment(portfolioId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_DATA));
+        Attachment attachment = memberPortfolio.getAttachment();
+        return attachmentService.download(attachment.getId());
     }
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberPortfolioService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberPortfolioService.java
@@ -2,6 +2,7 @@ package com.whatpl.domain.member.service;
 
 import com.whatpl.domain.attachment.domain.Attachment;
 import com.whatpl.domain.attachment.service.AttachmentService;
+import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.member.domain.MemberPortfolio;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,8 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -20,20 +19,15 @@ public class MemberPortfolioService {
     private final AttachmentService attachmentService;
 
     @Transactional
-    public List<MemberPortfolio> uploadPortfolio(List<MultipartFile> portfolios) {
+    public void uploadPortfolio(Member member, List<MultipartFile> portfolios) {
         if (CollectionUtils.isEmpty(portfolios)) {
-            return Collections.emptyList();
+            return;
         }
-
-        List<MemberPortfolio> memberPortfolios = new ArrayList<>();
         portfolios.parallelStream()
                 .forEach(portfolio -> {
-                    Long attachmentId = attachmentService.upload(portfolio);
-                    // 1차 캐시에 있는 데이터 조회 (쿼리X)
-                    Attachment attachment = attachmentService.findById(attachmentId);
+                    Attachment attachment = attachmentService.upload(portfolio);
                     MemberPortfolio memberPortfolio = new MemberPortfolio(attachment);
-                    memberPortfolios.add(memberPortfolio);
+                    member.addMemberPortfolio(memberPortfolio);
                 });
-        return memberPortfolios;
     }
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
@@ -26,7 +26,9 @@ public class MemberProfileService {
 
     private final MemberRepository memberRepository;
     private final MemberPortfolioService memberPortfolioService;
+    private final MemberPictureService memberPictureService;
     private final ApplicationEventPublisher publisher;
+    private final MemberMapper memberMapper;
 
     @Transactional(readOnly = true)
     public NicknameDuplResponse nicknameDuplCheck(final String nickname) {
@@ -73,7 +75,14 @@ public class MemberProfileService {
     public MemberProfileResponse readProfile(final long memberId) {
         Member member = memberRepository.findMemberWithAllById(memberId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
-        return MemberMapper.toMemberProfileResponse(member);
+        return memberMapper.toMemberProfileResponse(member);
+    }
+
+    @Transactional
+    public void updatePicture(long memberId, MultipartFile picture) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        memberPictureService.modifyPicture(member, picture);
     }
 
     private MemberEditor getMemberEditor(ProfileUpdateRequest request, Member member) {

--- a/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
@@ -3,10 +3,8 @@ package com.whatpl.domain.member.service;
 import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.member.domain.MemberEditor;
 import com.whatpl.domain.member.domain.MemberPortfolio;
-import com.whatpl.domain.member.dto.NicknameDuplResponse;
-import com.whatpl.domain.member.dto.ProfileOptionalRequest;
-import com.whatpl.domain.member.dto.ProfileRequiredRequest;
-import com.whatpl.domain.member.dto.ProfileUpdateRequest;
+import com.whatpl.domain.member.dto.*;
+import com.whatpl.domain.member.mapper.MemberMapper;
 import com.whatpl.domain.member.repository.MemberRepository;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
@@ -69,5 +67,12 @@ public class MemberProfileService {
                 .workTime(request.getWorkTime())
                 .build();
         member.updateProfile(memberEditor, request.getSubjects(), request.getReferences(), request.getSkills());
+    }
+
+    @Transactional(readOnly = true)
+    public MemberProfileResponse readProfile(final long memberId) {
+        Member member = memberRepository.findMemberWithAllById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        return MemberMapper.toMemberProfileResponse(member);
     }
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberProfileService.java
@@ -1,13 +1,15 @@
 package com.whatpl.domain.member.service;
 
-import com.whatpl.global.exception.BizException;
-import com.whatpl.global.exception.ErrorCode;
 import com.whatpl.domain.member.domain.Member;
+import com.whatpl.domain.member.domain.MemberEditor;
 import com.whatpl.domain.member.domain.MemberPortfolio;
 import com.whatpl.domain.member.dto.NicknameDuplResponse;
 import com.whatpl.domain.member.dto.ProfileOptionalRequest;
 import com.whatpl.domain.member.dto.ProfileRequiredRequest;
+import com.whatpl.domain.member.dto.ProfileUpdateRequest;
 import com.whatpl.domain.member.repository.MemberRepository;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -53,5 +55,19 @@ public class MemberProfileService {
         member.modifyMemberSubject(info.getSubjects());
         member.modifyMemberReference(info.getReferences());
         member.modifyWorkTime(info.getWorkTime());
+    }
+
+    @Transactional
+    public void updateProfile(ProfileUpdateRequest request, final long memberId) {
+        Member member = memberRepository.findMemberWithAllById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        MemberEditor memberEditor = member.toEditor()
+                .nickname(request.getNickname())
+                .job(request.getJob())
+                .career(request.getCareer())
+                .profileOpen(request.isProfileOpen())
+                .workTime(request.getWorkTime())
+                .build();
+        member.updateProfile(memberEditor, request.getSubjects(), request.getReferences(), request.getSkills());
     }
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberProjectService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberProjectService.java
@@ -3,6 +3,7 @@ package com.whatpl.domain.member.service;
 import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.member.repository.MemberRepository;
 import com.whatpl.domain.project.dto.ParticipatedProject;
+import com.whatpl.domain.project.dto.ProjectInfo;
 import com.whatpl.domain.project.service.ProjectReadService;
 import com.whatpl.global.exception.BizException;
 import com.whatpl.global.exception.ErrorCode;
@@ -22,5 +23,11 @@ public class MemberProjectService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
         return projectReadService.readParticipatedProject(member);
+    }
+
+    public List<ProjectInfo> readRecruitedProjects(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        return projectReadService.readRecruitedProjects(member);
     }
 }

--- a/src/main/java/com/whatpl/domain/member/service/MemberProjectService.java
+++ b/src/main/java/com/whatpl/domain/member/service/MemberProjectService.java
@@ -1,0 +1,26 @@
+package com.whatpl.domain.member.service;
+
+import com.whatpl.domain.member.domain.Member;
+import com.whatpl.domain.member.repository.MemberRepository;
+import com.whatpl.domain.project.dto.ParticipatedProject;
+import com.whatpl.domain.project.service.ProjectReadService;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberProjectService {
+
+    private final MemberRepository memberRepository;
+    private final ProjectReadService projectReadService;
+
+    public List<ParticipatedProject> readParticipatedProjects(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
+        return projectReadService.readParticipatedProject(member);
+    }
+}

--- a/src/main/java/com/whatpl/domain/project/dto/ParticipatedProject.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ParticipatedProject.java
@@ -15,7 +15,7 @@ public class ParticipatedProject {
 
     private final Long projectId;
     private final String title;
-    private final Long representImageId;
+    private final String representImageUrl;
     private final Subject subject;
     private final Job job;
     private final LocalDateTime participatedAt;

--- a/src/main/java/com/whatpl/domain/project/dto/ParticipatedProject.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ParticipatedProject.java
@@ -1,0 +1,22 @@
+package com.whatpl.domain.project.dto;
+
+import com.whatpl.global.common.model.Job;
+import com.whatpl.global.common.model.Subject;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ParticipatedProject {
+
+    private final Long projectId;
+    private final String title;
+    private final Long representImageId;
+    private final Subject subject;
+    private final Job job;
+    private final LocalDateTime participatedAt;
+}

--- a/src/main/java/com/whatpl/domain/project/dto/ParticipatedProjectResponse.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ParticipatedProjectResponse.java
@@ -1,0 +1,19 @@
+package com.whatpl.domain.project.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ParticipatedProjectResponse {
+
+    private final List<ParticipatedProject> participatedProjects;
+
+    public static ParticipatedProjectResponse from(List<ParticipatedProject> participatedProject) {
+        return new ParticipatedProjectResponse(participatedProject);
+    }
+}

--- a/src/main/java/com/whatpl/domain/project/dto/ProjectInfo.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ProjectInfo.java
@@ -26,7 +26,7 @@ public class ProjectInfo implements SliceElement {
     private int views;
     private int likes;
     private int comments;
-    private String representImageUri;
+    private Long representImageId;
 
     @Getter
     @Builder

--- a/src/main/java/com/whatpl/domain/project/dto/ProjectInfo.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ProjectInfo.java
@@ -6,6 +6,7 @@ import com.whatpl.global.pagination.SliceElement;
 import com.whatpl.domain.project.model.ProjectStatus;
 import lombok.*;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ public class ProjectInfo implements SliceElement {
     private int likes;
     private int comments;
     private Long representImageId;
+    private String representImageUrl;
 
     @Getter
     @Builder
@@ -36,6 +38,7 @@ public class ProjectInfo implements SliceElement {
         private List<RemainedJobDto> remainedJobs;
         private int likes;
         private int comments;
+        private String representImageUrl;
 
         public static Editor fromSkills(List<Skill> skills) {
             return Editor.builder().skills(skills).build();
@@ -53,6 +56,8 @@ public class ProjectInfo implements SliceElement {
             return Editor.builder().comments(comments).build();
         }
 
+        public static Editor fromRepresentImageUrl(String representImageUrl) {return Editor.builder().representImageUrl(representImageUrl).build();}
+
         public void merge(ProjectInfo original) {
             if (!CollectionUtils.isEmpty(skills)) {
                 original.skills = skills;
@@ -65,6 +70,9 @@ public class ProjectInfo implements SliceElement {
             }
             if (comments > 0) {
                 original.comments = comments;
+            }
+            if (StringUtils.hasText(representImageUrl)) {
+                original.representImageUrl = representImageUrl;
             }
         }
     }

--- a/src/main/java/com/whatpl/domain/project/dto/ProjectReadResponse.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ProjectReadResponse.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class ProjectReadResponse {
 
     private final long projectId;
-    private final Long representImageId;
+    private final String representImageUrl;
     private final String title;
     private final ProjectStatus projectStatus;
     private final Subject subject;

--- a/src/main/java/com/whatpl/domain/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/whatpl/domain/project/dto/ProjectSearchCondition.java
@@ -21,13 +21,14 @@ public class ProjectSearchCondition {
     private ProjectStatus status;
     private Boolean profitable;
     private String keyword;
-    private Long longinMemberId;
+    private Long memberId;
+    private Long recruiterId;
 
     public void assignLoginMember(MemberPrincipal principal) {
-        if (longinMemberId != null) {
+        if (memberId != null) {
             return;
         }
-        longinMemberId = principal != null ? principal.getId() : Long.MIN_VALUE;
+        memberId = principal != null ? principal.getId() : Long.MIN_VALUE;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/com/whatpl/domain/project/dto/RecruitedProjectResponse.java
+++ b/src/main/java/com/whatpl/domain/project/dto/RecruitedProjectResponse.java
@@ -1,0 +1,19 @@
+package com.whatpl.domain.project.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class RecruitedProjectResponse {
+
+    private final List<ProjectInfo> recruitedProjects;
+
+    public static RecruitedProjectResponse from(final List<ProjectInfo> recruitedProjects) {
+        return new RecruitedProjectResponse(recruitedProjects);
+    }
+}

--- a/src/main/java/com/whatpl/domain/project/mapper/ProjectMapper.java
+++ b/src/main/java/com/whatpl/domain/project/mapper/ProjectMapper.java
@@ -1,6 +1,7 @@
 package com.whatpl.domain.project.mapper;
 
 import com.whatpl.domain.attachment.domain.Attachment;
+import com.whatpl.domain.project.dto.ParticipatedProject;
 import com.whatpl.global.common.model.Job;
 import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.project.domain.Project;
@@ -116,5 +117,26 @@ public final class ProjectMapper {
                 .nickname(projectParticipant.getParticipant().getNickname())
                 .career(projectParticipant.getParticipant().getCareer())
                 .build();
+    }
+
+    public static ParticipatedProject toParticipatedProject(Member member, Project project) {
+        return ParticipatedProject.builder()
+                .projectId(project.getId())
+                .title(project.getTitle())
+                .representImageId(project.getRepresentImage() == null ? null : project.getRepresentImage().getId())
+                .subject(project.getSubject())
+                .job(getMatchedParticipant(member, project)
+                        .map(ProjectParticipant::getJob)
+                        .orElse(null))
+                .participatedAt(getMatchedParticipant(member, project)
+                        .map(ProjectParticipant::getCreatedAt)
+                        .orElse(null))
+                .build();
+    }
+
+    private static Optional<ProjectParticipant> getMatchedParticipant(Member member, Project project) {
+        return project.getProjectParticipants().stream()
+                .filter(projectParticipant -> projectParticipant.getParticipant().getId().equals(member.getId()))
+                .findFirst();
     }
 }

--- a/src/main/java/com/whatpl/domain/project/repository/project/ProjectRepository.java
+++ b/src/main/java/com/whatpl/domain/project/repository/project/ProjectRepository.java
@@ -19,4 +19,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
 
     @Query("select p from Project p left join fetch p.projectParticipants pp where pp.participant = :member")
     List<Project> findParticipatedProjects(Member member);
+
+    @Query("select p from Project p left join fetch p.representImage where p.representImage.id = :representImageId")
+    Optional<Project> findByRepresentImageId(Long representImageId);
 }

--- a/src/main/java/com/whatpl/domain/project/repository/project/ProjectRepository.java
+++ b/src/main/java/com/whatpl/domain/project/repository/project/ProjectRepository.java
@@ -1,10 +1,12 @@
 package com.whatpl.domain.project.repository.project;
 
+import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.project.domain.Project;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectQueryRepository {
@@ -14,4 +16,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
 
     @EntityGraph(attributePaths = {"writer"})
     Optional<Project> findWithWriterById(Long id);
+
+    @Query("select p from Project p left join fetch p.projectParticipants pp where pp.participant = :member")
+    List<Project> findParticipatedProjects(Member member);
 }

--- a/src/main/java/com/whatpl/domain/project/service/ProjectReadService.java
+++ b/src/main/java/com/whatpl/domain/project/service/ProjectReadService.java
@@ -1,20 +1,23 @@
 package com.whatpl.domain.project.service;
 
-import com.whatpl.global.exception.BizException;
-import com.whatpl.global.exception.ErrorCode;
-import com.whatpl.domain.project.mapper.ProjectMapper;
+import com.whatpl.domain.member.domain.Member;
 import com.whatpl.domain.project.domain.Project;
+import com.whatpl.domain.project.dto.ParticipatedProject;
 import com.whatpl.domain.project.dto.ProjectInfo;
 import com.whatpl.domain.project.dto.ProjectReadResponse;
 import com.whatpl.domain.project.dto.ProjectSearchCondition;
+import com.whatpl.domain.project.mapper.ProjectMapper;
 import com.whatpl.domain.project.repository.like.ProjectLikeRepository;
 import com.whatpl.domain.project.repository.project.ProjectRepository;
+import com.whatpl.global.exception.BizException;
+import com.whatpl.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -52,5 +55,14 @@ public class ProjectReadService {
         ).join();
 
         return projectInfos;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ParticipatedProject> readParticipatedProject(Member member) {
+        ArrayList<ParticipatedProject> result = new ArrayList<>();
+        projectRepository.findParticipatedProjects(member).forEach(project ->
+                result.add(ProjectMapper.toParticipatedProject(member, project))
+        );
+        return result;
     }
 }

--- a/src/main/java/com/whatpl/domain/project/service/ProjectWriteService.java
+++ b/src/main/java/com/whatpl/domain/project/service/ProjectWriteService.java
@@ -25,6 +25,7 @@ public class ProjectWriteService {
     private final MemberRepository memberRepository;
     private final AttachmentRepository attachmentRepository;
     private final ProjectRepository projectRepository;
+    private final ProjectMapper projectMapper;
 
     @Transactional
     @CacheEvict(value = "projectList", allEntries = true)
@@ -33,7 +34,7 @@ public class ProjectWriteService {
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_MEMBER));
 
         Attachment representImage = getRepresentImage(request.getRepresentImageId());
-        Project project = ProjectMapper.toProject(request, writer, representImage);
+        Project project = projectMapper.toProject(request, writer, representImage);
 
         Project savedProject = projectRepository.save(project);
         return savedProject.getId();
@@ -55,7 +56,6 @@ public class ProjectWriteService {
         }
         Attachment representImage = attachmentRepository.findById(representImageId)
                 .orElseThrow(() -> new BizException(ErrorCode.NOT_FOUND_FILE));
-        // 프로젝트 대표이미지는 이미지 파일만 가능 (web validation 단계에서 image, pdf 가 넘어오기 때문에 한번 더 체크)
         FileUtils.validateImageFile(representImage.getMimeType());
         return representImage;
     }

--- a/src/main/java/com/whatpl/external/upload/FileUploader.java
+++ b/src/main/java/com/whatpl/external/upload/FileUploader.java
@@ -6,4 +6,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface FileUploader {
     String upload(MultipartFile multipartFile);
     Resource download(String key);
+    void delete(String key);
 }

--- a/src/main/java/com/whatpl/external/upload/S3Uploader.java
+++ b/src/main/java/com/whatpl/external/upload/S3Uploader.java
@@ -22,6 +22,7 @@ public class S3Uploader implements FileUploader {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
+    @Override
     public String upload(MultipartFile multipartFile) {
         String storedName = UUID.randomUUID().toString();
         try (InputStream is = multipartFile.getInputStream()) {
@@ -33,11 +34,17 @@ public class S3Uploader implements FileUploader {
         return storedName;
     }
 
+    @Override
     public Resource download(String key) {
         S3Resource resource = s3Template.download(bucket, key);
         if (!resource.exists()) {
             throw new BizException(ErrorCode.NOT_FOUND_FILE);
         }
         return resource;
+    }
+
+    @Override
+    public void delete(String key) {
+        s3Template.deleteObject(bucket, key);
     }
 }

--- a/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
+++ b/src/main/java/com/whatpl/global/config/MethodSecurityConfig.java
@@ -24,6 +24,7 @@ public class MethodSecurityConfig {
     private final ProjectLikePermissionManager projectLikePermissionManager;
     private final ParticipantPermissionManager participantPermissionManager;
     private final ChatMessagePermissionManager chatMessagePermissionManager;
+    private final MemberPermissionManager memberPermissionManager;
 
     @Bean
     public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
@@ -34,6 +35,7 @@ public class MethodSecurityConfig {
         whatplPermissionEvaluatorMap.put("PROJECT_LIKE", projectLikePermissionManager);
         whatplPermissionEvaluatorMap.put("PARTICIPANT", participantPermissionManager);
         whatplPermissionEvaluatorMap.put("CHAT_MESSAGE", chatMessagePermissionManager);
+        whatplPermissionEvaluatorMap.put("MEMBER", memberPermissionManager);
 
         DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
         expressionHandler.setPermissionEvaluator(new WhatplPermissionEvaluator(whatplPermissionEvaluatorMap));

--- a/src/main/java/com/whatpl/global/security/permission/manager/MemberPermissionManager.java
+++ b/src/main/java/com/whatpl/global/security/permission/manager/MemberPermissionManager.java
@@ -1,0 +1,28 @@
+package com.whatpl.global.security.permission.manager;
+
+import com.whatpl.global.security.domain.MemberPrincipal;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Component
+public class MemberPermissionManager implements WhatplPermissionManager {
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasPrivilege(MemberPrincipal memberPrincipal, Long targetId, String permission) {
+        return switch (permission) {
+            case "UPDATE" -> hasUpdatePrivilege(memberPrincipal, targetId);
+            default -> false;
+        };
+    }
+
+    /**
+     * 멤버 수정 권한
+     * 자기 자신
+     */
+    private boolean hasUpdatePrivilege(MemberPrincipal memberPrincipal, Long memberId) {
+        return Objects.equals(memberId, memberPrincipal.getId());
+    }
+}

--- a/src/main/java/com/whatpl/global/web/validator/MultipartPictureValidator.java
+++ b/src/main/java/com/whatpl/global/web/validator/MultipartPictureValidator.java
@@ -1,0 +1,31 @@
+package com.whatpl.global.web.validator;
+
+import com.whatpl.global.util.FileUtils;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Set;
+
+import static org.springframework.http.MediaType.*;
+
+public class MultipartPictureValidator implements ConstraintValidator<ValidPicture, MultipartFile> {
+
+    private static final Set<String> allowedTypes = Set.of(IMAGE_JPEG_VALUE, IMAGE_PNG_VALUE);
+
+    @Override
+    public boolean isValid(MultipartFile multipartFile, ConstraintValidatorContext context) {
+        return hasExtension(multipartFile) && isAllowedType(multipartFile);
+    }
+
+    private boolean hasExtension(MultipartFile multipartFile) {
+        return StringUtils.hasText(StringUtils.getFilenameExtension(multipartFile.getOriginalFilename()));
+    }
+
+    private boolean isAllowedType(MultipartFile multipartFile) {
+        String mimeType = FileUtils.extractMimeType(multipartFile);
+        return allowedTypes.stream()
+                .anyMatch(type -> type.equals(mimeType));
+    }
+}

--- a/src/main/java/com/whatpl/global/web/validator/ValidPicture.java
+++ b/src/main/java/com/whatpl/global/web/validator/ValidPicture.java
@@ -1,0 +1,21 @@
+package com.whatpl.global.web.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = ElementType.PARAMETER)
+@Retention(value = RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MultipartPictureValidator.class)
+public @interface ValidPicture {
+
+    String message() default "허용된 확장자가 아닙니다. [jpg, jpeg, png]";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,8 @@ default-image:
     project: DEFAULT_IMAGE_PROJECT
     skill: DEFAULT_IMAGE_SKILL
 
+server-url: http://localhost:8080
+
 # 운영 prod
 ---
 spring:
@@ -129,3 +131,4 @@ spring:
           kakao:
             redirect-uri: https://whatpl.com/oauth2/callback/kakao
 
+server-url: https://jewoos.site

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -4,15 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whatpl.domain.attachment.service.AttachmentService;
 import com.whatpl.domain.chat.service.ChatMessageService;
 import com.whatpl.domain.chat.service.ChatRoomService;
-import com.whatpl.domain.project.service.*;
-import com.whatpl.domain.whatplpople.service.WhatplpeopleService;
-import com.whatpl.global.config.SecurityConfig;
-import com.whatpl.global.common.properties.ImageProperties;
-import com.whatpl.global.common.properties.JwtProperties;
-import com.whatpl.global.jwt.service.JwtService;
-import com.whatpl.external.upload.FileUploader;
 import com.whatpl.domain.member.service.MemberLoginService;
 import com.whatpl.domain.member.service.MemberProfileService;
+import com.whatpl.domain.member.service.MemberProjectService;
+import com.whatpl.domain.project.service.*;
+import com.whatpl.domain.whatplpople.service.WhatplpeopleService;
+import com.whatpl.external.upload.FileUploader;
+import com.whatpl.global.common.properties.ImageProperties;
+import com.whatpl.global.common.properties.JwtProperties;
+import com.whatpl.global.config.SecurityConfig;
+import com.whatpl.global.jwt.service.JwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -85,6 +86,9 @@ public abstract class BaseSecurityWebMvcTest {
 
     @MockBean
     protected WhatplpeopleService whatplpeopleService;
+
+    @MockBean
+    protected MemberProjectService memberProjectService;
 
     @BeforeEach
     protected void init() {

--- a/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
+++ b/src/test/java/com/whatpl/BaseSecurityWebMvcTest.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whatpl.domain.attachment.service.AttachmentService;
 import com.whatpl.domain.chat.service.ChatMessageService;
 import com.whatpl.domain.chat.service.ChatRoomService;
-import com.whatpl.domain.member.service.MemberLoginService;
-import com.whatpl.domain.member.service.MemberProfileService;
-import com.whatpl.domain.member.service.MemberProjectService;
+import com.whatpl.domain.member.service.*;
 import com.whatpl.domain.project.service.*;
 import com.whatpl.domain.whatplpople.service.WhatplpeopleService;
 import com.whatpl.external.upload.FileUploader;
@@ -89,6 +87,12 @@ public abstract class BaseSecurityWebMvcTest {
 
     @MockBean
     protected MemberProjectService memberProjectService;
+
+    @MockBean
+    protected MemberPortfolioService memberPortfolioService;
+
+    @MockBean
+    protected MemberPictureService memberPictureService;
 
     @BeforeEach
     protected void init() {

--- a/src/test/java/com/whatpl/domain/attachment/service/AttachmentServiceTest.java
+++ b/src/test/java/com/whatpl/domain/attachment/service/AttachmentServiceTest.java
@@ -3,7 +3,6 @@ package com.whatpl.domain.attachment.service;
 import com.whatpl.domain.attachment.domain.Attachment;
 import com.whatpl.domain.attachment.dto.ResourceDto;
 import com.whatpl.domain.attachment.repository.AttachmentRepository;
-import com.whatpl.domain.attachment.service.AttachmentService;
 import com.whatpl.external.upload.FileUploader;
 import io.awspring.cloud.s3.S3Resource;
 import org.junit.jupiter.api.DisplayName;
@@ -45,7 +44,7 @@ class AttachmentServiceTest {
                 .thenReturn(mock(Attachment.class));
 
         //when
-        attachmentService.upload(multipartFile);
+        attachmentService.uploadAndSave(multipartFile);
 
         //then
         verify(fileUploader, times(1)).upload(multipartFile);

--- a/src/test/java/com/whatpl/domain/chat/controller/ChatMessageControllerTest.java
+++ b/src/test/java/com/whatpl/domain/chat/controller/ChatMessageControllerTest.java
@@ -93,7 +93,8 @@ class ChatMessageControllerTest extends BaseSecurityWebMvcTest {
                 .content("메시지입니다~")
                 .senderId(1L)
                 .senderNickname("왓플테스트멤버1")
-                .senderProfileImgUri(null) // TODO 보낸 사람 프로필 이미지 URI
+                .senderPictureId(1L)
+                .senderPictureUrl("https://jewoos.site/attachments/pictures/1")
                 .sendAt(LocalDateTime.now(Clock.fixed(
                         Instant.parse("2024-05-06T23:24:43.00Z"),
                         ZoneId.of("Asia/Seoul"))))
@@ -117,7 +118,8 @@ class ChatMessageControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.list[*].content").value(chatMessageDto.getContent()),
                         jsonPath("$.list[*].senderId").value(Long.valueOf(chatMessageDto.getSenderId()).intValue()),
                         jsonPath("$.list[*].senderNickname").value(chatMessageDto.getSenderNickname()),
-                        jsonPath("$.list[*].senderProfileImgUri").value(chatMessageDto.getSenderProfileImgUri()),
+                        jsonPath("$.list[*].senderPictureId").value(Long.valueOf(chatMessageDto.getSenderPictureId()).intValue()),
+                        jsonPath("$.list[*].senderPictureUrl").value(chatMessageDto.getSenderPictureUrl()),
                         jsonPath("$.list[*].sendAt").value(chatMessageDto.getSendAt().toString()),
                         jsonPath("$.list[*].readAt").value(chatMessageDto.getReadAt().toString()),
                         jsonPath("$.currentPage").value(page),
@@ -155,7 +157,8 @@ class ChatMessageControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("list[].content").type(JsonFieldType.STRING).description("메시지 내용"),
                                 fieldWithPath("list[].senderId").type(JsonFieldType.NUMBER).description("발송자 ID"),
                                 fieldWithPath("list[].senderNickname").type(JsonFieldType.STRING).description("발송자 닉네임"),
-                                fieldWithPath("list[].senderProfileImgUri").type(JsonFieldType.NULL).description("발송자 프로필 이미지 URI"), // TODO 보낸 사람 프로필 이미지 URI
+                                fieldWithPath("list[].senderPictureId").type(JsonFieldType.NUMBER).description("발송자 프로필 이미지 ID"),
+                                fieldWithPath("list[].senderPictureUrl").type(JsonFieldType.STRING).description("발송자 프로필 이미지 URL"),
                                 fieldWithPath("list[].sendAt").type(JsonFieldType.STRING).description("발송 일시"),
                                 fieldWithPath("list[].readAt").type(JsonFieldType.STRING).description("수신 일시"),
                                 fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),

--- a/src/test/java/com/whatpl/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/whatpl/domain/chat/controller/ChatRoomControllerTest.java
@@ -52,7 +52,8 @@ class ChatRoomControllerTest extends BaseSecurityWebMvcTest {
                 .projectTitle("프로젝트 제목")
                 .opponentId(1L)
                 .opponentNickname("상대방 닉네임")
-                .opponentProfileImgUri("상대방 프로필 URI")
+                .opponentPictureId(1L)
+                .opponentPictureUrl("https://jewoos.site/attachments/pictures/1")
                 .lastMessageContent("마지막 메시지")
                 .lastMessageTime(LocalDateTime.now(Clock.fixed(
                         Instant.parse("2024-07-17T23:55:01.00Z"),
@@ -76,7 +77,8 @@ class ChatRoomControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.list[*].projectTitle").value(chatRoomResponse.getProjectTitle()),
                         jsonPath("$.list[*].opponentId").value(Long.valueOf(chatRoomResponse.getOpponentId()).intValue()),
                         jsonPath("$.list[*].opponentNickname").value(chatRoomResponse.getOpponentNickname()),
-                        jsonPath("$.list[*].opponentProfileImgUri").value(chatRoomResponse.getOpponentProfileImgUri()),
+                        jsonPath("$.list[*].opponentPictureId").value(Long.valueOf(chatRoomResponse.getOpponentPictureId()).intValue()),
+                        jsonPath("$.list[*].opponentPictureUrl").value(chatRoomResponse.getOpponentPictureUrl()),
                         jsonPath("$.list[*].lastMessageContent").value(chatRoomResponse.getLastMessageContent()),
                         jsonPath("$.list[*].lastMessageTime").value(chatRoomResponse.getLastMessageTime().toString()),
                         jsonPath("$.list[*].lastMessageRead").value(chatRoomResponse.isLastMessageRead())
@@ -104,7 +106,8 @@ class ChatRoomControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("list[].projectTitle").type(JsonFieldType.STRING).description("프로젝트 제목"),
                                 fieldWithPath("list[].opponentId").type(JsonFieldType.NUMBER).description("상대방 멤버 ID"),
                                 fieldWithPath("list[].opponentNickname").type(JsonFieldType.STRING).description("상대방 멤버 닉네임"),
-                                fieldWithPath("list[].opponentProfileImgUri").type(JsonFieldType.STRING).description("상대방 멤버 프로필 이미지 URI"),
+                                fieldWithPath("list[].opponentPictureId").type(JsonFieldType.NUMBER).description("상대방 멤버 프로필 이미지 ID"),
+                                fieldWithPath("list[].opponentPictureUrl").type(JsonFieldType.STRING).description("상대방 멤버 프로필 이미지 URL"),
                                 fieldWithPath("list[].lastMessageContent").type(JsonFieldType.STRING).description("마지막 메시지 내용"),
                                 fieldWithPath("list[].lastMessageTime").type(JsonFieldType.STRING).description("마지막 메시지 발송 일시"),
                                 fieldWithPath("list[].lastMessageRead").type(JsonFieldType.BOOLEAN).description("마지막 메시지 읽음 여부"),

--- a/src/test/java/com/whatpl/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/whatpl/domain/member/controller/MemberControllerTest.java
@@ -160,7 +160,7 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
 
     @Test
     @WithMockWhatplMember
-    @DisplayName("프로필 기본 정보 입력 API Docs")
+    @DisplayName("프로필 선택 정보 입력 API Docs")
     void optional() throws Exception {
         // given
         ProfileOptionalRequest info = ProfileOptionalRequestFixture.create();

--- a/src/test/java/com/whatpl/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/whatpl/domain/member/controller/MemberControllerTest.java
@@ -3,6 +3,8 @@ package com.whatpl.domain.member.controller;
 import com.whatpl.ApiDocTag;
 import com.whatpl.ApiDocUtils;
 import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.domain.member.dto.MemberProfileResponse;
+import com.whatpl.domain.member.model.MemberProfileResponseFixture;
 import com.whatpl.global.security.model.WithMockWhatplMember;
 import com.whatpl.global.common.model.Career;
 import com.whatpl.global.common.model.Job;
@@ -30,8 +32,7 @@ import java.util.Set;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
@@ -183,23 +184,23 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
                                 .summary("프로필 선택 정보 입력")
                                 .description("""
                                         프로필 선택 정보 입력
-                                                                                
+                                        
                                         현재 사용 플러그인(ePages/restdocs-api-spec)이 multipart/form-data 문서화가 지원되지 않습니다. (try it out 불가능)
-
+                                        
                                         아래 형식을 참고하여 요청하면 됩니다.
                                         
                                         <h2> JSON Part </h2>
                                         | name   | Content-Type           | Description          |
                                         |--------|------------------------| ---------------------|
                                         | info   | application/json       | Member 프로필 정보     |
-                                                                                
+                                        
                                         <h2> JSON Field Part - info </h2>
                                         | key         | Type       | Description          |
                                         |-------------|------------| ---------------------|
                                         | subjects    | List       | 관심주제               |
                                         | references  | List       | 참고링크               |
                                         | workTime    | String     | 작업시간               |
-                                                                                
+                                        
                                         <h2> File Part </h2>
                                         | name         | filename  |Content-Type                 | Description            |
                                         |--------------|-----------|-----------------------------| -----------------------|
@@ -217,6 +218,43 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("references").description("참고링크"),
                                 fieldWithPath("workTime").description("작업시간"))
 
+                ));
+    }
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("멤버 프로필 조회")
+    void readProfile() throws Exception {
+        // given
+        MemberProfileResponse memberProfileResponse = MemberProfileResponseFixture.generate();
+        when(memberProfileService.readProfile(anyLong())).thenReturn(memberProfileResponse);
+
+        // expected
+        mockMvc.perform(get("/members/{memberId}", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("read-profile",
+                        resourceDetails()
+                                .tag(ApiDocTag.MEMBER.getTag())
+                                .summary("멤버 프로필 조회")
+                                .description("""
+                                        멤버 프로필을 조회합니다.
+                                        """),
+                        pathParameters(
+                                parameterWithName("memberId").description("조회할 멤버 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                fieldWithPath("job").type(JsonFieldType.STRING).description("직무"),
+                                fieldWithPath("career").type(JsonFieldType.STRING).description("연차"),
+                                fieldWithPath("workTime").type(JsonFieldType.STRING).description("작업 가능 시간"),
+                                fieldWithPath("profileOpen").type(JsonFieldType.BOOLEAN).description("프로필 오픈 여부"),
+                                fieldWithPath("skills").type(JsonFieldType.ARRAY).description("스킬"),
+                                fieldWithPath("subjects").type(JsonFieldType.ARRAY).description("관심 주제"),
+                                fieldWithPath("references").type(JsonFieldType.ARRAY).description("참고 링크"),
+                                fieldWithPath("portfolioIds").type(JsonFieldType.ARRAY).description("포트폴리오 ID")
+                        )
                 ));
     }
 }

--- a/src/test/java/com/whatpl/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/whatpl/domain/member/controller/MemberControllerTest.java
@@ -3,16 +3,14 @@ package com.whatpl.domain.member.controller;
 import com.whatpl.ApiDocTag;
 import com.whatpl.ApiDocUtils;
 import com.whatpl.BaseSecurityWebMvcTest;
-import com.whatpl.domain.member.dto.MemberProfileResponse;
+import com.whatpl.domain.member.dto.*;
 import com.whatpl.domain.member.model.MemberProfileResponseFixture;
-import com.whatpl.global.security.model.WithMockWhatplMember;
+import com.whatpl.domain.member.model.ProfileOptionalRequestFixture;
+import com.whatpl.domain.member.model.ProfileUpdateRequestFixture;
 import com.whatpl.global.common.model.Career;
 import com.whatpl.global.common.model.Job;
 import com.whatpl.global.common.model.Skill;
-import com.whatpl.domain.member.dto.NicknameDuplResponse;
-import com.whatpl.domain.member.dto.ProfileOptionalRequest;
-import com.whatpl.domain.member.dto.ProfileRequiredRequest;
-import com.whatpl.domain.member.model.ProfileOptionalRequestFixture;
+import com.whatpl.global.security.model.WithMockWhatplMember;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,8 +22,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -255,6 +255,91 @@ class MemberControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("references").type(JsonFieldType.ARRAY).description("참고 링크"),
                                 fieldWithPath("portfolioIds").type(JsonFieldType.ARRAY).description("포트폴리오 ID")
                         )
+                ));
+    }
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("프로필 수정 API Docs")
+    void updateProfile() throws Exception {
+        // given
+        ProfileUpdateRequest info = ProfileUpdateRequestFixture.create();
+        String infoJson = objectMapper.writeValueAsString(info);
+        MockMultipartFile infoRequest = new MockMultipartFile("info", "", MediaType.APPLICATION_JSON_VALUE, infoJson.getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile mockMultipartFile1 = createMockMultipartFile("portfolios", "cat.jpg", MediaType.IMAGE_JPEG_VALUE);
+        MockMultipartFile mockMultipartFile2 = createMockMultipartFile("portfolios", "dummy.pdf", MediaType.IMAGE_PNG_VALUE);
+        doNothing().when(memberProfileService).updateProfile(any(ProfileUpdateRequest.class), anyList(), any(Long.class));
+
+        MockMultipartHttpServletRequestBuilder customRestDocumentationRequestBuilder =
+                RestDocumentationRequestBuilders.multipart("/members/{memberId}", 1L);
+
+        customRestDocumentationRequestBuilder.with(request -> {
+            request.setMethod("PUT");
+            return request;
+        });
+        // expected
+        mockMvc.perform(customRestDocumentationRequestBuilder
+                        .file(infoRequest)
+                        .file(mockMultipartFile1)
+                        .file(mockMultipartFile2)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("update-profile",
+                        resourceDetails()
+                                .tag(ApiDocTag.MEMBER.getTag())
+                                .summary("프로필 수정")
+                                .description("""
+                                        프로필 수정
+                                        
+                                        현재 사용 플러그인(ePages/restdocs-api-spec)이 multipart/form-data 문서화가 지원되지 않습니다. (try it out 불가능)
+                                        
+                                        아래 형식을 참고하여 요청하면 됩니다.
+                                        
+                                        <h2> JSON Part </h2>
+                                        | name   | Content-Type           | Description          |
+                                        |--------|------------------------| ---------------------|
+                                        | info   | application/json       | Member 프로필 정보     |
+                                        
+                                        <h2> JSON Field Part - info </h2>
+                                        | key                | Type    | Description      |
+                                        |--------------------|---------| -----------------|
+                                        | nickname           | String  | 닉네임            |
+                                        | job                | String  | 직무              |
+                                        | career             | String  | 경력              |
+                                        | skills             | List    | 스킬셋            |
+                                        | profileOpen        | Boolean | 프로필 공개 여부    |
+                                        | subjects           | List    | 관심주제           |
+                                        | references         | List    | 참고링크           |
+                                        | workTime           | String  | 작업시간           |
+                                        | deletePortfolioIds | List    | 삭제할 포트폴리오 ID |
+                                        
+                                        <h2> File Part </h2>
+                                        | name         | filename  |Content-Type                 | Description            |
+                                        |--------------|-----------|-----------------------------| -----------------------|
+                                        | portfolios   | 파일명     | multipart/form-data         | 포트폴리오 첨부파일        |
+                                        """),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken"),
+                                headerWithName(CONTENT_TYPE).description(MULTIPART_FORM_DATA_VALUE)
+                        ),
+                        pathParameters(
+                                parameterWithName("memberId").description("수정할 멤버 ID")
+                        ),
+                        requestParts(
+                                partWithName("info").description("선택정보"),
+                                partWithName("portfolios").description("포트폴리오")
+                        ),
+                        requestPartFields("info",
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                fieldWithPath("job").type(JsonFieldType.STRING).description("직무"),
+                                fieldWithPath("career").type(JsonFieldType.STRING).description("경력"),
+                                fieldWithPath("skills").type(JsonFieldType.ARRAY).description("스킬셋"),
+                                fieldWithPath("profileOpen").type(JsonFieldType.BOOLEAN).description("프로필 공개 여부"),
+                                fieldWithPath("subjects").type(JsonFieldType.ARRAY).description("관심주제"),
+                                fieldWithPath("references").type(JsonFieldType.ARRAY).description("참고링크"),
+                                fieldWithPath("workTime").type(JsonFieldType.STRING).description("작업시간"),
+                                fieldWithPath("deletePortfolioIds").type(JsonFieldType.ARRAY).description("삭제할 포트폴리오 ID"))
                 ));
     }
 }

--- a/src/test/java/com/whatpl/domain/member/controller/MemberProjectControllerTest.java
+++ b/src/test/java/com/whatpl/domain/member/controller/MemberProjectControllerTest.java
@@ -48,7 +48,7 @@ class MemberProjectControllerTest extends BaseSecurityWebMvcTest {
         ParticipatedProject result = ParticipatedProject.builder()
                 .projectId(1L)
                 .title("프로젝트1")
-                .representImageId(1L)
+                .representImageUrl("https://jewoos.site/images/project")
                 .subject(Subject.ART)
                 .job(Job.BACKEND_DEVELOPER)
                 .participatedAt(LocalDateTime.now(Clock.fixed(
@@ -76,7 +76,7 @@ class MemberProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("participatedProjects").type(JsonFieldType.ARRAY).description("프로젝트 리스트"),
                                 fieldWithPath("participatedProjects[].projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
                                 fieldWithPath("participatedProjects[].title").type(JsonFieldType.STRING).description("프로젝트 제목"),
-                                fieldWithPath("participatedProjects[].representImageId").type(JsonFieldType.NUMBER).description("프로젝트 대표 이미지 ID"),
+                                fieldWithPath("participatedProjects[].representImageUrl").type(JsonFieldType.STRING).description("프로젝트 대표 이미지 URL"),
                                 fieldWithPath("participatedProjects[].subject").type(JsonFieldType.STRING).description("프로젝트 주제"),
                                 fieldWithPath("participatedProjects[].job").type(JsonFieldType.STRING).description("참여한 직무"),
                                 fieldWithPath("participatedProjects[].participatedAt").type(JsonFieldType.STRING).description("참여 일시")
@@ -105,6 +105,7 @@ class MemberProjectControllerTest extends BaseSecurityWebMvcTest {
                 .likes(20)
                 .comments(5)
                 .representImageId(1L)
+                .representImageUrl("https://jewoos.site/attachments/projects/represent-images/1")
                 .myLike(true)
                 .build();
         List<ProjectInfo> projectInfos = List.of(projectInfo);
@@ -143,6 +144,7 @@ class MemberProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("recruitedProjects[].likes").type(JsonFieldType.NUMBER).description("좋아요 갯수"),
                                 fieldWithPath("recruitedProjects[].comments").type(JsonFieldType.NUMBER).description("댓글 갯수"),
                                 fieldWithPath("recruitedProjects[].representImageId").type(JsonFieldType.NUMBER).description("대표 이미지 ID"),
+                                fieldWithPath("recruitedProjects[].representImageUrl").type(JsonFieldType.STRING).description("대표 이미지 URL"),
                                 fieldWithPath("recruitedProjects[].myLike").type(JsonFieldType.BOOLEAN).description("좋아요 여부")
                         )
                 ));

--- a/src/test/java/com/whatpl/domain/member/controller/MemberProjectControllerTest.java
+++ b/src/test/java/com/whatpl/domain/member/controller/MemberProjectControllerTest.java
@@ -1,0 +1,82 @@
+package com.whatpl.domain.member.controller;
+
+import com.whatpl.ApiDocTag;
+import com.whatpl.BaseSecurityWebMvcTest;
+import com.whatpl.domain.project.dto.ParticipatedProject;
+import com.whatpl.global.common.model.Job;
+import com.whatpl.global.common.model.Subject;
+import com.whatpl.global.security.model.WithMockWhatplMember;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+class MemberProjectControllerTest extends BaseSecurityWebMvcTest {
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("참여한 프로젝트 조회")
+    void readParticipatedProject() throws Exception {
+        // given
+        ParticipatedProject result = ParticipatedProject.builder()
+                .projectId(1L)
+                .title("프로젝트1")
+                .representImageId(1L)
+                .subject(Subject.ART)
+                .job(Job.BACKEND_DEVELOPER)
+                .participatedAt(LocalDateTime.now(Clock.fixed(
+                        Instant.parse("2024-09-30T23:55:01.00Z"),
+                        ZoneId.of("Asia/Seoul"))))
+                .build();
+        when(memberProjectService.readParticipatedProjects(anyLong())).thenReturn(List.of(result));
+
+        // expected
+        mockMvc.perform(get("/members/{memberId}/projects/participated", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("read-participated-project",
+                        resourceDetails()
+                                .tag(ApiDocTag.MEMBER.getTag())
+                                .summary("참여한 프로젝트 조회")
+                                .description("""
+                                        멤버의 참여한 프로젝트를 조회합니다.
+                                        """),
+                        pathParameters(
+                                parameterWithName("memberId").description("멤버 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("participatedProjects").type(JsonFieldType.ARRAY).description("프로젝트 ID"),
+                                fieldWithPath("participatedProjects[].projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
+                                fieldWithPath("participatedProjects[].title").type(JsonFieldType.STRING).description("프로젝트 제목"),
+                                fieldWithPath("participatedProjects[].representImageId").type(JsonFieldType.NUMBER).description("프로젝트 대표 이미지 ID"),
+                                fieldWithPath("participatedProjects[].subject").type(JsonFieldType.STRING).description("프로젝트 주제"),
+                                fieldWithPath("participatedProjects[].job").type(JsonFieldType.STRING).description("참여한 직무"),
+                                fieldWithPath("participatedProjects[].participatedAt").type(JsonFieldType.STRING).description("참여 일시")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/whatpl/domain/member/controller/MemberProjectControllerTest.java
+++ b/src/test/java/com/whatpl/domain/member/controller/MemberProjectControllerTest.java
@@ -3,7 +3,11 @@ package com.whatpl.domain.member.controller;
 import com.whatpl.ApiDocTag;
 import com.whatpl.BaseSecurityWebMvcTest;
 import com.whatpl.domain.project.dto.ParticipatedProject;
+import com.whatpl.domain.project.dto.ProjectInfo;
+import com.whatpl.domain.project.dto.RemainedJobDto;
+import com.whatpl.domain.project.model.ProjectStatus;
 import com.whatpl.global.common.model.Job;
+import com.whatpl.global.common.model.Skill;
 import com.whatpl.global.common.model.Subject;
 import com.whatpl.global.security.model.WithMockWhatplMember;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 
@@ -27,10 +32,9 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
@@ -69,13 +73,77 @@ class MemberProjectControllerTest extends BaseSecurityWebMvcTest {
                                 parameterWithName("memberId").description("멤버 ID")
                         ),
                         responseFields(
-                                fieldWithPath("participatedProjects").type(JsonFieldType.ARRAY).description("프로젝트 ID"),
+                                fieldWithPath("participatedProjects").type(JsonFieldType.ARRAY).description("프로젝트 리스트"),
                                 fieldWithPath("participatedProjects[].projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
                                 fieldWithPath("participatedProjects[].title").type(JsonFieldType.STRING).description("프로젝트 제목"),
                                 fieldWithPath("participatedProjects[].representImageId").type(JsonFieldType.NUMBER).description("프로젝트 대표 이미지 ID"),
                                 fieldWithPath("participatedProjects[].subject").type(JsonFieldType.STRING).description("프로젝트 주제"),
                                 fieldWithPath("participatedProjects[].job").type(JsonFieldType.STRING).description("참여한 직무"),
                                 fieldWithPath("participatedProjects[].participatedAt").type(JsonFieldType.STRING).description("참여 일시")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockWhatplMember
+    @DisplayName("모집한 프로젝트 조회")
+    void readRecruitedProject() throws Exception {
+        // given
+        ProjectInfo projectInfo = ProjectInfo.builder()
+                .projectId(1L)
+                .title("테스트 프로젝트 1")
+                .status(ProjectStatus.RECRUITING)
+                .subject(Subject.SOCIAL_MEDIA)
+                .skills(List.of(Skill.JAVA, Skill.FIGMA))
+                .remainedJobs(List.of(RemainedJobDto.builder()
+                        .job(Job.BACKEND_DEVELOPER)
+                        .recruitAmount(5)
+                        .remainedAmount(2)
+                        .build()))
+                .profitable(false)
+                .views(100)
+                .likes(20)
+                .comments(5)
+                .representImageId(1L)
+                .myLike(true)
+                .build();
+        List<ProjectInfo> projectInfos = List.of(projectInfo);
+        when(memberProjectService.readRecruitedProjects(anyLong())).thenReturn(projectInfos);
+
+        // expected
+        mockMvc.perform(get("/members/{memberId}/projects/recruited", 1L)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer {AccessToken}"))
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON_VALUE)
+                )
+                .andDo(print())
+                .andDo(document("read-recruited-project",
+                        resourceDetails().tag(ApiDocTag.MEMBER.getTag())
+                                .summary("모집한 프로젝트 조회")
+                                .description("""
+                                        멤버의 모집한 프로젝트를 조회합니다.
+                                        """),
+                        pathParameters(
+                                parameterWithName("memberId").description("멤버 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("recruitedProjects").type(JsonFieldType.ARRAY).description("프로젝트 리스트"),
+                                fieldWithPath("recruitedProjects[].projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
+                                fieldWithPath("recruitedProjects[].title").type(JsonFieldType.STRING).description("프로젝트 제목"),
+                                fieldWithPath("recruitedProjects[].status").type(JsonFieldType.STRING).description("프로젝트 상태"),
+                                fieldWithPath("recruitedProjects[].subject").type(JsonFieldType.STRING).description("프로젝트 도메인"),
+                                fieldWithPath("recruitedProjects[].skills").type(JsonFieldType.ARRAY).description("프로젝트 기술 스택"),
+                                fieldWithPath("recruitedProjects[].remainedJobs").type(JsonFieldType.ARRAY).description("남은 모집 직무(아직 모집 중인 직무)"),
+                                fieldWithPath("recruitedProjects[].remainedJobs[].job").type(JsonFieldType.STRING).description("직무"),
+                                fieldWithPath("recruitedProjects[].remainedJobs[].recruitAmount").type(JsonFieldType.NUMBER).description("총 모집 인원"),
+                                fieldWithPath("recruitedProjects[].remainedJobs[].remainedAmount").type(JsonFieldType.NUMBER).description("남은 모집 인원"),
+                                fieldWithPath("recruitedProjects[].profitable").type(JsonFieldType.BOOLEAN).description("수익화 여부"),
+                                fieldWithPath("recruitedProjects[].views").type(JsonFieldType.NUMBER).description("조회수"),
+                                fieldWithPath("recruitedProjects[].likes").type(JsonFieldType.NUMBER).description("좋아요 갯수"),
+                                fieldWithPath("recruitedProjects[].comments").type(JsonFieldType.NUMBER).description("댓글 갯수"),
+                                fieldWithPath("recruitedProjects[].representImageId").type(JsonFieldType.NUMBER).description("대표 이미지 ID"),
+                                fieldWithPath("recruitedProjects[].myLike").type(JsonFieldType.BOOLEAN).description("좋아요 여부")
                         )
                 ));
     }

--- a/src/test/java/com/whatpl/domain/member/model/MemberProfileResponseFixture.java
+++ b/src/test/java/com/whatpl/domain/member/model/MemberProfileResponseFixture.java
@@ -1,0 +1,23 @@
+package com.whatpl.domain.member.model;
+
+import com.whatpl.domain.member.dto.MemberProfileResponse;
+import com.whatpl.global.common.model.*;
+
+import java.util.Set;
+
+public class MemberProfileResponseFixture {
+
+    public static MemberProfileResponse generate() {
+        return MemberProfileResponse.builder()
+                .nickname("왓플테스트멤버1")
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.SIX)
+                .workTime(WorkTime.THIRTY_TO_FORTY)
+                .profileOpen(true)
+                .skills(Set.of(Skill.NODE, Skill.JAVA))
+                .subjects(Set.of(Subject.FINANCE, Subject.HEALTH))
+                .references(Set.of("https://google.com", "https://github.com"))
+                .portfolioIds(Set.of(1L, 2L, 3L))
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/domain/member/model/MemberProfileResponseFixture.java
+++ b/src/test/java/com/whatpl/domain/member/model/MemberProfileResponseFixture.java
@@ -3,7 +3,7 @@ package com.whatpl.domain.member.model;
 import com.whatpl.domain.member.dto.MemberProfileResponse;
 import com.whatpl.global.common.model.*;
 
-import java.util.Set;
+import java.util.List;
 
 public class MemberProfileResponseFixture {
 
@@ -14,10 +14,14 @@ public class MemberProfileResponseFixture {
                 .career(Career.SIX)
                 .workTime(WorkTime.THIRTY_TO_FORTY)
                 .profileOpen(true)
-                .skills(Set.of(Skill.NODE, Skill.JAVA))
-                .subjects(Set.of(Subject.FINANCE, Subject.HEALTH))
-                .references(Set.of("https://google.com", "https://github.com"))
-                .portfolioIds(Set.of(1L, 2L, 3L))
+                .skills(List.of(Skill.NODE, Skill.JAVA))
+                .subjects(List.of(Subject.FINANCE, Subject.HEALTH))
+                .references(List.of("https://google.com", "https://github.com"))
+                .portfolioUrls(List.of(
+                        "https://jewoos.site/attachments/portfolios/1",
+                        "https://jewoos.site/attachments/portfolios/2"
+                ))
+                .pictureUrl("https://jewoos.site/attachments/picture/1")
                 .build();
     }
 }

--- a/src/test/java/com/whatpl/domain/member/model/ProfileOptionalRequestFixture.java
+++ b/src/test/java/com/whatpl/domain/member/model/ProfileOptionalRequestFixture.java
@@ -11,7 +11,7 @@ public class ProfileOptionalRequestFixture {
     public static ProfileOptionalRequest create() {
         return ProfileOptionalRequest.builder()
                 .subjects(Set.of(Subject.HEALTH, Subject.SOCIAL_MEDIA))
-                .references(Set.of("https://github.com", "https://https://notefolio.net"))
+                .references(Set.of("https://github.com", "https://notefolio.net"))
                 .workTime(WorkTime.THIRTY_TO_FORTY)
                 .build();
     }

--- a/src/test/java/com/whatpl/domain/member/model/ProfileUpdateRequestFixture.java
+++ b/src/test/java/com/whatpl/domain/member/model/ProfileUpdateRequestFixture.java
@@ -1,0 +1,24 @@
+package com.whatpl.domain.member.model;
+
+import com.whatpl.domain.member.dto.ProfileUpdateRequest;
+import com.whatpl.global.common.model.*;
+
+import java.util.List;
+import java.util.Set;
+
+public class ProfileUpdateRequestFixture {
+
+    public static ProfileUpdateRequest create() {
+        return ProfileUpdateRequest.builder()
+                .nickname("닉네임")
+                .job(Job.BACKEND_DEVELOPER)
+                .career(Career.SIX)
+                .skills(Set.of(Skill.NODE, Skill.FIREBASE))
+                .profileOpen(true)
+                .subjects(Set.of(Subject.HEALTH, Subject.SOCIAL_MEDIA))
+                .references(Set.of("https://github.com", "https://notefolio.net"))
+                .workTime(WorkTime.THIRTY_TO_FORTY)
+                .deletePortfolioIds(List.of(1L, 2L))
+                .build();
+    }
+}

--- a/src/test/java/com/whatpl/domain/member/repository/MemberQueryRepositoryImplTest.java
+++ b/src/test/java/com/whatpl/domain/member/repository/MemberQueryRepositoryImplTest.java
@@ -36,6 +36,5 @@ class MemberQueryRepositoryImplTest extends BaseRepositoryTest {
         assertEquals(member.getMemberReferences().size(), findMember.getMemberReferences().size());
         assertEquals(member.getMemberPortfolios().size(), findMember.getMemberPortfolios().size());
         assertNotNull(member.getMemberPortfolios());
-        assertEquals(member, member.getMemberPortfolios().get(0).getMember());
     }
 }

--- a/src/test/java/com/whatpl/domain/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/whatpl/domain/member/service/MemberProfileServiceTest.java
@@ -1,18 +1,16 @@
 package com.whatpl.domain.member.service;
 
-import com.whatpl.domain.attachment.domain.Attachment;
 import com.whatpl.domain.member.domain.Member;
-import com.whatpl.domain.member.domain.MemberPortfolio;
 import com.whatpl.domain.member.domain.MemberSkill;
-import com.whatpl.global.common.model.Career;
-import com.whatpl.global.common.model.Job;
-import com.whatpl.global.common.model.Skill;
 import com.whatpl.domain.member.dto.NicknameDuplResponse;
 import com.whatpl.domain.member.dto.ProfileOptionalRequest;
 import com.whatpl.domain.member.dto.ProfileRequiredRequest;
 import com.whatpl.domain.member.model.MemberFixture;
 import com.whatpl.domain.member.model.ProfileOptionalRequestFixture;
 import com.whatpl.domain.member.repository.MemberRepository;
+import com.whatpl.global.common.model.Career;
+import com.whatpl.global.common.model.Job;
+import com.whatpl.global.common.model.Skill;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,11 +23,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -114,11 +112,7 @@ class MemberProfileServiceTest {
         List<MultipartFile> portfolios = List.of(
                 new MockMultipartFile("testFile1", "testFile1".getBytes()),
                 new MockMultipartFile("testFile2", "testFile2".getBytes()));
-        when(memberPortfolioService.uploadPortfolio(portfolios))
-                .thenReturn(List.of(
-                        new MemberPortfolio(new Attachment("testFile1", UUID.randomUUID().toString(), "image/jpeg")),
-                        new MemberPortfolio(new Attachment("testFile2", UUID.randomUUID().toString(), "image/png")))
-                );
+        doNothing().when(memberPortfolioService).uploadPortfolio(member, portfolios);
 
         // when
         memberProfileService.updateOptionalProfile(request, portfolios, 0L);
@@ -127,6 +121,5 @@ class MemberProfileServiceTest {
         assertEquals(request.getReferences().size(), member.getMemberReferences().size());
         assertEquals(request.getSubjects().size(), member.getMemberSubjects().size());
         assertEquals(request.getWorkTime(), member.getWorkTime());
-        assertEquals(portfolios.size(), member.getMemberPortfolios().size());
     }
 }

--- a/src/test/java/com/whatpl/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/domain/project/controller/ProjectControllerTest.java
@@ -205,7 +205,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .views(100)
                 .likes(20)
                 .comments(5)
-                .representImageUri("/images/default?type=project")
+                .representImageId(1L)
                 .myLike(true)
                 .build();
         List<ProjectInfo> projectInfos = List.of(projectInfo);
@@ -243,7 +243,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.list[*].views").value(projectInfo.getViews()),
                         jsonPath("$.list[*].likes").value(projectInfo.getLikes()),
                         jsonPath("$.list[*].comments").value(projectInfo.getComments()),
-                        jsonPath("$.list[*].representImageUri").value(projectInfo.getRepresentImageUri()),
+                        jsonPath("$.list[*].representImageId").value(Long.valueOf(projectInfo.getRepresentImageId()).intValue()),
                         jsonPath("$.list[*].myLike").value(projectInfo.isMyLike())
                 )
                 .andDo(print())
@@ -287,7 +287,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("list[].views").type(JsonFieldType.NUMBER).description("조회수"),
                                 fieldWithPath("list[].likes").type(JsonFieldType.NUMBER).description("좋아요 갯수"),
                                 fieldWithPath("list[].comments").type(JsonFieldType.NUMBER).description("댓글 갯수"),
-                                fieldWithPath("list[].representImageUri").type(JsonFieldType.STRING).description("대표 이미지 URI"),
+                                fieldWithPath("list[].representImageId").type(JsonFieldType.NUMBER).description("대표 이미지 ID"),
                                 fieldWithPath("list[].myLike").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                 fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),
                                 fieldWithPath("pageSize").type(JsonFieldType.NUMBER).description("페이지 사이즈"),

--- a/src/test/java/com/whatpl/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/whatpl/domain/project/controller/ProjectControllerTest.java
@@ -101,7 +101,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .andExpectAll(
                         status().isOk(),
                         jsonPath("$.projectId").value(response.getProjectId()),
-                        jsonPath("$.representImageId").value(response.getRepresentImageId()),
+                        jsonPath("$.representImageUrl").value(response.getRepresentImageUrl()),
                         jsonPath("$.title").value(response.getTitle()),
                         jsonPath("$.projectStatus").value(response.getProjectStatus().getValue()),
                         jsonPath("$.meetingType").value(response.getMeetingType().getValue()),
@@ -154,7 +154,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         ),
                         responseFields(
                                 fieldWithPath("projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID"),
-                                fieldWithPath("representImageId").type(JsonFieldType.NUMBER).description("대표이미지 ID"),
+                                fieldWithPath("representImageUrl").type(JsonFieldType.STRING).description("대표이미지 URL"),
                                 fieldWithPath("title").type(JsonFieldType.STRING).description("프로젝트 제목"),
                                 fieldWithPath("projectStatus").type(JsonFieldType.STRING).description("프로젝트 상태"),
                                 fieldWithPath("meetingType").type(JsonFieldType.STRING).description("모임 방식"),
@@ -206,6 +206,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                 .likes(20)
                 .comments(5)
                 .representImageId(1L)
+                .representImageUrl("https://jewoos.site/attachments/projects/represent-images/1")
                 .myLike(true)
                 .build();
         List<ProjectInfo> projectInfos = List.of(projectInfo);
@@ -244,6 +245,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                         jsonPath("$.list[*].likes").value(projectInfo.getLikes()),
                         jsonPath("$.list[*].comments").value(projectInfo.getComments()),
                         jsonPath("$.list[*].representImageId").value(Long.valueOf(projectInfo.getRepresentImageId()).intValue()),
+                        jsonPath("$.list[*].representImageUrl").value(projectInfo.getRepresentImageUrl()),
                         jsonPath("$.list[*].myLike").value(projectInfo.isMyLike())
                 )
                 .andDo(print())
@@ -288,6 +290,7 @@ class ProjectControllerTest extends BaseSecurityWebMvcTest {
                                 fieldWithPath("list[].likes").type(JsonFieldType.NUMBER).description("좋아요 갯수"),
                                 fieldWithPath("list[].comments").type(JsonFieldType.NUMBER).description("댓글 갯수"),
                                 fieldWithPath("list[].representImageId").type(JsonFieldType.NUMBER).description("대표 이미지 ID"),
+                                fieldWithPath("list[].representImageUrl").type(JsonFieldType.STRING).description("대표 이미지 URL"),
                                 fieldWithPath("list[].myLike").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
                                 fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지"),
                                 fieldWithPath("pageSize").type(JsonFieldType.NUMBER).description("페이지 사이즈"),

--- a/src/test/java/com/whatpl/domain/project/model/ProjectReadResponseFixture.java
+++ b/src/test/java/com/whatpl/domain/project/model/ProjectReadResponseFixture.java
@@ -16,7 +16,7 @@ public class ProjectReadResponseFixture {
     public static ProjectReadResponse from(final Long projectId) {
         return ProjectReadResponse.builder()
                 .projectId(projectId)
-                .representImageId(1L)
+                .representImageUrl("https://jewoos.site/images/project")
                 .title("테스트 프로젝트")
                 .projectStatus(ProjectStatus.RECRUITING)
                 .meetingType(MeetingType.ONLINE)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #94 

## 📝작업 내용

- 멤버 프로필 기능 모두 완료했습니다.
  - 프로필 수정, 프로필 조회, 프로필 사진 등록
- 서비스 전역에서 사용할 수 있는 이미지 조회 Url Parser를 만들었습니다.
  - 이미지 조회 Url Parser를 사용하려면 `AttachmentUrlParseDelegator`를 사용하면 됩니다.
  - parseUrl() 메서드는 `AttachmentUrlParseType` enum타입과 해당 타입에 맞는 id값을 넣어 호출하면 됩니다.
  - `AttachmentUrlParseType`는 멤버 프로필, 멤버 포트폴리오, 프로젝트 대표 이미지가 있습니다.

## 💬리뷰 요구사항(선택)

- `AttachmentUrlParseDelegator`의 사용법을 코드로 확인해보시고, 궁금하신 점은 댓글이나 슬랙 주시면 답변 드리겠습니다.
